### PR TITLE
chore: remove obsolete `neverExpires` field from access key spec

### DIFF
--- a/api/v1alpha1/accesskey_types.go
+++ b/api/v1alpha1/accesskey_types.go
@@ -25,14 +25,6 @@ type AccessKeySpec struct {
 	// The name of the secret that will be created to store the credentials.
 	// +kubebuilder:validation:Required
 	SecretName string `json:"secretName"`
-
-	// NeverExpires is an experimental (draft) field. Set the access key to never expire.
-	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
-	NeverExpires bool `json:"neverExpires,omitempty"`
-
-	// TODO: TBD: viability without credential rotation?
-	// Expiration time.Time
 }
 
 // AccessKeyStatus defines the observed state of AccessKey.

--- a/config/crd/bases/garage.getclustered.net_accesskeys.yaml
+++ b/config/crd/bases/garage.getclustered.net_accesskeys.yaml
@@ -46,13 +46,6 @@ spec:
           spec:
             description: spec defines the desired state of AccessKey
             properties:
-              neverExpires:
-                description: NeverExpires is an experimental (draft) field. Set the
-                  access key to never expire.
-                type: boolean
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
               secretName:
                 description: The name of the secret that will be created to store
                   the credentials.

--- a/internal/controller/accesskey_controller_test.go
+++ b/internal/controller/accesskey_controller_test.go
@@ -73,8 +73,7 @@ var _ = Describe("AccessKey Controller", func() {
 						Namespace: "default",
 					},
 					Spec: garagev1alpha1.AccessKeySpec{
-						SecretName:   "some-ns-secret",
-						NeverExpires: true,
+						SecretName: "some-ns-secret",
 					},
 				}
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())


### PR DESCRIPTION
Field not needed, keys do not expire by default.

Related to #44 