### PR TITLE
fix: Suppress conflict errors in logs

### DIFF
--- a/internal/controller/accesskey_controller.go
+++ b/internal/controller/accesskey_controller.go
@@ -134,6 +134,9 @@ func (r *AccessKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 		a.Status = accessKey.Status
 		err = r.client.Status().Update(ctx, &a)
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/accesspolicy_controller.go
+++ b/internal/controller/accesspolicy_controller.go
@@ -133,6 +133,9 @@ func (r *AccessPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if metaChanged {
 		err = r.client.Update(ctx, &policy)
 		if err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{}, nil
+			}
 			return ctrl.Result{}, fmt.Errorf("updating object meta: %w", err)
 		}
 		// let the next reconciliation loop handle this update:
@@ -164,6 +167,9 @@ func (r *AccessPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if !equality.Semantic.DeepEqual(*oldStatus, policy.Status) {
 		err = r.client.Status().Patch(ctx, &policy, client.Merge, client.FieldOwner(bucketControllerName))
 		if err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{}, nil
+			}
 			return ctrl.Result{}, err
 		}
 	}

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -118,8 +118,13 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if !equality.Semantic.DeepEqual(*orig, bucket.Status) {
 		patchErr := r.client.Status().Patch(ctx, &bucket, client.Merge, client.FieldOwner(bucketControllerName))
 
-		if err == nil && patchErr != nil {
-			return ctrl.Result{}, patchErr
+		if patchErr != nil {
+			if apierrors.IsConflict(patchErr) {
+				return ctrl.Result{}, nil
+			}
+			if err == nil {
+				return ctrl.Result{}, patchErr
+			}
 		}
 	}
 


### PR DESCRIPTION
Multiple reconciles of the access policy in quick succession cause conflict errors on update:
- AccessPolicy created 
- AccessKey created -> filtered watch fires reconcile on AccessPolicy
- Bucket created -> another reconcile
- AccessKey / Bucket ready -> reconcile

At leats one of these is triggered with a stale state in the client cache. Since state is updated before the work item is queued, the final update will always happen before the last Reconcile request is enqueued.

The error in the controller log causes the e2e test to fail.

Example:
```
2026-06-04T10:43:05Z	ERROR	Reconciler error	{"controller": "accesspolicy", "controllerGroup": "garage.getclustered.net", "controllerKind": "AccessPolicy", "AccessPolicy": {"name":"accesspolicy-sample","namespace":"e2e-2198909340"}, "namespace": "e2e-2198909340", "name": "accesspolicy-sample", "reconcileID": "382cbea4-0fc0-44d7-bf39-479c4083fab6", "error": "Operation cannot be fulfilled on accesspolicies.garage.getclustered.net \"accesspolicy-sample\": the object has been modified; please apply your changes to the latest version and try again"}
```

Fix:
Since state is updated before the work item is queued, the reconcile triggered by the conflicting write will always read consistent state. 

Returning ctrl.Result{}, nil and discarding the conflict is safe. 

Refs:
- controller-runtime [reconcile](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.24.1/pkg/internal/controller/controller.go#L483-L513)
- k8s [client-go](https://github.com/kubernetes/client-go/blob/v0.34.3/tools/cache/controller.go#L554)
