### PR TITLE
fix: default controller log level to INFO

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,9 +81,7 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	opts := zap.Options{
-		Development: true,
-	}
+	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,13 +85,13 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
 	cfg, err := loadConfig()
 	if err != nil {
 		setupLog.Error(err, "loading controller config")
 		os.Exit(1)
 	}
-
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will


### PR DESCRIPTION
Log level was set to DEBUG in main at some point during development. Passing zap log level flags currently has no effect.