### PR TITLE
fix: send nil instead of zero for unset bucket quotas

### DIFF
--- a/internal/garage/api_types.go
+++ b/internal/garage/api_types.go
@@ -1,5 +1,7 @@
 package garage
 
+import "github.com/bmarinov/garage-storage-controller/internal/s3"
+
 type BucketUpdateRequest struct {
 	Quotas Quotas `json:"quotas"`
 }
@@ -11,8 +13,30 @@ type BucketResponse struct {
 }
 
 type Quotas struct {
-	MaxObjects int64 `json:"maxObjects"`
-	MaxSize    int64 `json:"maxSize"`
+	MaxObjects *int64 `json:"maxObjects"`
+	MaxSize    *int64 `json:"maxSize,omitempty"`
+}
+
+func quotasFromS3(q s3.Quotas) Quotas {
+	var g Quotas
+	if q.MaxObjects > 0 {
+		g.MaxObjects = &q.MaxObjects
+	}
+	if q.MaxSize > 0 {
+		g.MaxSize = &q.MaxSize
+	}
+	return g
+}
+
+func quotasToS3(q Quotas) s3.Quotas {
+	var out s3.Quotas
+	if q.MaxObjects != nil {
+		out.MaxObjects = *q.MaxObjects
+	}
+	if q.MaxSize != nil {
+		out.MaxSize = *q.MaxSize
+	}
+	return out
 }
 
 type CreateKeyRequest struct {

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -200,46 +200,52 @@ func (b *BucketClient) Create(ctx context.Context, globalAlias string) (s3.Bucke
 	return s3.Bucket{
 		ID:            result.ID,
 		GlobalAliases: result.GlobalAliases,
-		Quotas:        s3.Quotas(result.Quotas),
+		Quotas:        quotasToS3(result.Quotas),
 	}, err
 }
 
 func (b *BucketClient) Get(ctx context.Context, globalAlias string) (s3.Bucket, error) {
+	result, err := b.getBucketResponse(ctx, globalAlias)
+	if err != nil {
+		return s3.Bucket{}, err
+	}
+	return s3.Bucket{
+		ID:            result.ID,
+		GlobalAliases: result.GlobalAliases,
+		Quotas:        quotasToS3(result.Quotas),
+	}, nil
+}
+
+func (b *BucketClient) getBucketResponse(ctx context.Context, globalAlias string) (BucketResponse, error) {
 	params := url.Values{}
-	// params.Add("id", bucketID)
 	params.Add("globalAlias", globalAlias)
 
 	const path = "/v2/GetBucketInfo"
 
 	resp, err := b.doRequest(ctx, http.MethodGet, path, &params, nil)
 	if err != nil {
-		return s3.Bucket{}, fmt.Errorf("retrieve bucket '%s': %w", globalAlias, err)
+		return BucketResponse{}, fmt.Errorf("retrieve bucket '%s': %w", globalAlias, err)
 	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusNotFound {
-			return s3.Bucket{}, fmt.Errorf("%w: with alias %s", s3.ErrResourceNotFound, globalAlias)
+			return BucketResponse{}, fmt.Errorf("%w: with alias %s", s3.ErrResourceNotFound, globalAlias)
 		}
-		return s3.Bucket{}, fmt.Errorf("unexpected status code %d", resp.StatusCode)
+		return BucketResponse{}, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
 
 	result, err := unmarshalBody[BucketResponse](resp.Body)
 	if err != nil {
-		return s3.Bucket{}, fmt.Errorf("reading %s response: %w", path, err)
+		return BucketResponse{}, fmt.Errorf("reading %s response: %w", path, err)
 	}
-
-	return s3.Bucket{
-		ID:            result.ID,
-		GlobalAliases: result.GlobalAliases,
-		Quotas:        s3.Quotas(result.Quotas),
-	}, err
+	return result, nil
 }
 
 func (b *BucketClient) Update(ctx context.Context, id string, quotas s3.Quotas) error {
 	request := BucketUpdateRequest{
-		Quotas: Quotas(quotas),
+		Quotas: quotasFromS3(quotas),
 	}
 
 	var buf bytes.Buffer

--- a/internal/garage/client_test.go
+++ b/internal/garage/client_test.go
@@ -124,29 +124,50 @@ func TestGarageClient_BucketAPI(t *testing.T) {
 	sut := NewClient(garageEnv.AdminAPIAddr, garageEnv.APIToken).
 		BucketClient
 
-	t.Run("zero MaxObjects in bucket quota", func(t *testing.T) {
-		bucketName := fixture.RandAlpha(12)
-		bucket, _ := sut.Create(t.Context(), bucketName)
-
-		requested := s3.Quotas{
-			MaxObjects: 0,
-			MaxSize:    234,
+	t.Run("zero quota fields are not enforced as limits", func(t *testing.T) {
+		testCases := []struct {
+			desc      string
+			requested s3.Quotas
+		}{
+			{"zero MaxObjects", s3.Quotas{MaxObjects: 0, MaxSize: 234}},
+			{"zero MaxSize", s3.Quotas{MaxObjects: 9500, MaxSize: 0}},
+			{"both zero", s3.Quotas{MaxObjects: 0, MaxSize: 0}},
 		}
+		for _, tc := range testCases {
+			t.Run(tc.desc, func(t *testing.T) {
+				bucket, _ := sut.Create(t.Context(), fixture.RandAlpha(12))
 
-		err := sut.Update(t.Context(), bucket.ID, requested)
+				err := sut.Update(t.Context(), bucket.ID, tc.requested)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				raw, err := sut.getBucketResponse(t.Context(), bucket.GlobalAliases[0])
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if tc.requested.MaxObjects == 0 && raw.Quotas.MaxObjects != nil {
+					t.Errorf("[%s] MaxObjects: want nil, got %d", tc.desc, *raw.Quotas.MaxObjects)
+				}
+				if tc.requested.MaxSize == 0 && raw.Quotas.MaxSize != nil {
+					t.Errorf("[%s] MaxSize: want nil, got %d", tc.desc, *raw.Quotas.MaxSize)
+				}
+			})
+		}
+	})
+	t.Run("set MaxSize is returned in response when no MaxObjects requested", func(t *testing.T) {
+		bucket, _ := sut.Create(t.Context(), fixture.RandAlpha(12))
+		err := sut.Update(t.Context(), bucket.ID, s3.Quotas{MaxSize: 234})
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		retrieved, err := sut.getBucketResponse(t.Context(), bucket.GlobalAliases[0])
+		raw, err := sut.getBucketResponse(t.Context(), bucket.GlobalAliases[0])
 		if err != nil {
 			t.Fatal(err)
 		}
-		if requested.MaxSize != *retrieved.Quotas.MaxSize {
-			t.Errorf("MaxSize quota does not match: expected %v got %v", requested.MaxSize, *retrieved.Quotas.MaxSize)
-		}
-		if retrieved.Quotas.MaxObjects != nil {
-			t.Errorf("bucket quotas should not be set to the literal zero value, got %+v", retrieved.Quotas)
+		if raw.Quotas.MaxSize == nil || *raw.Quotas.MaxSize != 234 {
+			t.Errorf("MaxSize: want 234, got %v", raw.Quotas.MaxSize)
 		}
 	})
 }

--- a/internal/garage/client_test.go
+++ b/internal/garage/client_test.go
@@ -120,6 +120,37 @@ func TestBucketClient(t *testing.T) {
 	})
 }
 
+func TestGarageClient_BucketAPI(t *testing.T) {
+	sut := NewClient(garageEnv.AdminAPIAddr, garageEnv.APIToken).
+		BucketClient
+
+	t.Run("zero MaxObjects in bucket quota", func(t *testing.T) {
+		bucketName := fixture.RandAlpha(12)
+		bucket, _ := sut.Create(t.Context(), bucketName)
+
+		requested := s3.Quotas{
+			MaxObjects: 0,
+			MaxSize:    234,
+		}
+
+		err := sut.Update(t.Context(), bucket.ID, requested)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		retrieved, err := sut.getBucketResponse(t.Context(), bucket.GlobalAliases[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if requested.MaxSize != *retrieved.Quotas.MaxSize {
+			t.Errorf("MaxSize quota does not match: expected %v got %v", requested.MaxSize, *retrieved.Quotas.MaxSize)
+		}
+		if retrieved.Quotas.MaxObjects != nil {
+			t.Errorf("bucket quotas should not be set to the literal zero value, got %+v", retrieved.Quotas)
+		}
+	})
+}
+
 func TestAccessKeyClient(t *testing.T) {
 	apiclient := NewClient(garageEnv.AdminAPIAddr, garageEnv.APIToken)
 	sut := apiclient.AccessKeyClient


### PR DESCRIPTION
When maxObjects is omitted from BucketSpec, the API client creates a bucket with zero max objects quota. 

Fix: 
Zero meaning no limit is now enforced in the controller-internal Garage client.