### PR TITLE
controller(bucket): Emit events when new Garage buckets are created

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -215,6 +215,7 @@ func main() {
 		garageClient.BucketClient,
 		cfg.garageS3Endpoint,
 		garageClient.PermissionClient,
+		mgr.GetEventRecorderFor("garage-bucket-controller"),
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Bucket")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,13 @@ metadata:
   name: garage-controller-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - garage.getclustered.net
   resources:
   - accesskeys

--- a/internal/controller/accesspolicy_manager_test.go
+++ b/internal/controller/accesspolicy_manager_test.go
@@ -61,7 +61,7 @@ var _ = Describe("AccessPolicy controller manager", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// sync with manager setup in main:
-		Expect(NewBucketReconciler(mgr.GetClient(), mgr.GetScheme(), newS3APIFake(), "http://s3.test.foo", nil).
+		Expect(NewBucketReconciler(mgr.GetClient(), mgr.GetScheme(), newS3APIFake(), "http://s3.test.foo", nil, mgr.GetEventRecorderFor("garage-bucket-controller")).
 			SetupWithManager(mgr)).To(Succeed())
 		Expect(NewAccessKeyReconciler(mgr.GetClient(), mgr.GetScheme(), newAccessMgrFake()).
 			SetupWithManager(mgr)).To(Succeed())

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -303,6 +303,7 @@ func (r *BucketReconciler) resolveNewBucket(ctx context.Context, bucket *garagev
 			s3Bucket, err = r.bucket.Create(ctx, alias)
 			if err != nil {
 				markBucketNotReady(bucket, "CreateFailed", "Failed to create bucket '%s': %v", alias, err)
+				r.recorder.Eventf(bucket, corev1.EventTypeWarning, ReasonBucketCreateFailed, "Failed to create Garage bucket %q: %v", alias, err)
 				return s3.Bucket{}, "", fmt.Errorf("create new bucket: %w", err)
 			}
 			r.recorder.Eventf(bucket, corev1.EventTypeNormal, ReasonBucketCreated, "Created Garage bucket %q", alias)

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -62,6 +63,7 @@ type BucketReconciler struct {
 	bucket        BucketClient
 	s3APIEndpoint string
 	ownership     OwnershipVerifier
+	recorder      record.EventRecorder
 	// baseRequeueInterval to override in tests. Base delay for the exponential backoff.
 	baseRequeueInterval time.Duration
 }
@@ -72,6 +74,7 @@ func NewBucketReconciler(
 	s3Client BucketClient,
 	s3APIEndpoint string,
 	ownershipVerifier OwnershipVerifier,
+	recorder record.EventRecorder,
 ) *BucketReconciler {
 	return &BucketReconciler{
 		client:              apiClient,
@@ -79,6 +82,7 @@ func NewBucketReconciler(
 		bucket:              s3Client,
 		s3APIEndpoint:       s3APIEndpoint,
 		ownership:           ownershipVerifier,
+		recorder:            recorder,
 		baseRequeueInterval: 5 * time.Second,
 	}
 }
@@ -94,6 +98,7 @@ func (r *BucketReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=garage.getclustered.net,resources=buckets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=garage.getclustered.net,resources=buckets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=garage.getclustered.net,resources=buckets/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	bucket := garagev1alpha1.Bucket{}
@@ -300,6 +305,7 @@ func (r *BucketReconciler) resolveNewBucket(ctx context.Context, bucket *garagev
 				markBucketNotReady(bucket, "CreateFailed", "Failed to create bucket '%s': %v", alias, err)
 				return s3.Bucket{}, "", fmt.Errorf("create new bucket: %w", err)
 			}
+			r.recorder.Eventf(bucket, corev1.EventTypeNormal, ReasonBucketCreated, "Created Garage bucket %q", alias)
 		} else {
 			markBucketNotReady(bucket, "UnknownState", "S3 API error: %v", err)
 			return s3.Bucket{}, "", fmt.Errorf("retrieving existing bucket: %w", err)

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -285,6 +285,22 @@ var _ = Describe("Bucket Controller", func() {
 			Consistently(rec.Events).ShouldNot(Receive())
 		})
 
+		It("should emit BucketCreateFailed event when creation fails in Garage", func() {
+			By("creating a Bucket resource")
+			bucket := newBucket(namespace)
+			Expect(k8sClient.Create(ctx, &bucket)).To(Succeed())
+
+			By("reconciling against a Garage fake that fails to create the bucket")
+			rec := record.NewFakeRecorder(10)
+			s3Fake := failCreateS3APIFake{s3APIFake: newS3APIFake(), err: errors.New("garage unavailable")}
+			sut := NewBucketReconciler(k8sClient, k8sClient.Scheme(), s3Fake, "https://s3.test:9000", nil, rec)
+			_, err := sut.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName(bucket.ObjectMeta)})
+			Expect(err).To(HaveOccurred())
+
+			By("receiving BucketCreateFailed event")
+			Eventually(rec.Events).Should(Receive(ContainSubstring("Warning BucketCreateFailed")))
+		})
+
 		It("recovers from conflict once configMapName is set", func() {
 			conflictingName := "foobar"
 			originalData := map[string]string{"foo": "bar"}
@@ -821,3 +837,16 @@ func (s *s3APIFake) Get(ctx context.Context, globalAlias string) (s3.Bucket, err
 }
 
 var _ BucketClient = &s3APIFake{}
+
+// failCreateS3APIFake wraps the fake Bucket client and forces Create to fail.
+// Get and Update are unchanged.
+type failCreateS3APIFake struct {
+	*s3APIFake
+	err error
+}
+
+func (f failCreateS3APIFake) Create(context.Context, string) (s3.Bucket, error) {
+	return s3.Bucket{}, f.err
+}
+
+var _ BucketClient = failCreateS3APIFake{}

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	corev1 "k8s.io/api/core/v1"
@@ -63,7 +64,7 @@ var _ = Describe("Bucket Controller", func() {
 			By("reconciling")
 			var s3Fake = newS3APIFake()
 			s3Endpoint := "https://foo.bar:3456/baz"
-			controllerReconciler := NewBucketReconciler(k8sClient, k8sClient.Scheme(), s3Fake, s3Endpoint, nil)
+			controllerReconciler := NewBucketReconciler(k8sClient, k8sClient.Scheme(), s3Fake, s3Endpoint, nil, record.NewFakeRecorder(10))
 
 			_, err := controllerReconciler.Reconcile(ctx,
 				reconcile.Request{NamespacedName: namespacedName(bucket.ObjectMeta)})
@@ -107,7 +108,7 @@ var _ = Describe("Bucket Controller", func() {
 			Expect(k8sClient.Create(ctx, &resource)).To(Succeed())
 			var s3Fake = newS3APIFake()
 			s3API := "https://s3.test.fooz:3909"
-			sut := NewBucketReconciler(k8sClient, k8sClient.Scheme(), s3Fake, s3API, nil)
+			sut := NewBucketReconciler(k8sClient, k8sClient.Scheme(), s3Fake, s3API, nil, record.NewFakeRecorder(10))
 
 			// Note: need to reconcile with Eventually once finalizer is added:
 			_, err := sut.Reconcile(ctx,
@@ -220,6 +221,68 @@ var _ = Describe("Bucket Controller", func() {
 			Expect(readyCondition).ToNot(BeNil())
 			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse), "top-level Ready must be false")
 			Expect(readyCondition.Reason).To(Equal(ReasonConfigMapNameConflict), "should reflect underlying configuration conflict")
+		})
+
+		It("should emit BucketCreated event when bucket is first created in Garage", func() {
+			By("creating a Bucket resource")
+			bucket := newBucket(namespace)
+			Expect(k8sClient.Create(ctx, &bucket)).To(Succeed())
+
+			By("reconciling against a fresh Garage fake")
+			rec := record.NewFakeRecorder(10)
+			s3Fake := newS3APIFake()
+			sut := NewBucketReconciler(k8sClient, k8sClient.Scheme(), s3Fake, "https://s3.test:9000", nil, rec)
+			_, err := sut.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName(bucket.ObjectMeta)})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("receiving BucketCreated event")
+			Eventually(rec.Events).Should(Receive(ContainSubstring("Normal BucketCreated")))
+		})
+
+		It("should not emit events when bucket already exists in Garage", func() {
+			By("creating a Bucket resource")
+			bucket := newBucket(namespace)
+			Expect(k8sClient.Create(ctx, &bucket)).To(Succeed())
+
+			By("pre-seeding existing bucket in the Garage instance")
+			rec := record.NewFakeRecorder(10)
+			s3Fake := newS3APIFake()
+			alias := suffixedResourceName(bucket.Spec.Name, bucket.ObjectMeta)
+			s3Fake.buckets["existing-id"] = s3.Bucket{ID: "existing-id", GlobalAliases: []string{alias}}
+			sut := NewBucketReconciler(k8sClient, k8sClient.Scheme(), s3Fake, "https://s3.test:9001", nil, rec)
+
+			By("reconciling")
+			_, err := sut.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName(bucket.ObjectMeta)})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("asserting no events were emitted")
+			Consistently(rec.Events).ShouldNot(Receive())
+		})
+
+		It("should emit BucketCreated exactly once across several reconciles", func() {
+			By("creating a Bucket")
+			bucket := newBucket(namespace)
+			Expect(k8sClient.Create(ctx, &bucket)).To(Succeed())
+
+			By("reconciling and creating the Garage bucket")
+			rec := record.NewFakeRecorder(10)
+			s3Fake := newS3APIFake()
+			sut := NewBucketReconciler(k8sClient, k8sClient.Scheme(), s3Fake, "https://s3.test:9000", nil, rec)
+			_, err := sut.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName(bucket.ObjectMeta)})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(rec.Events).Should(Receive(ContainSubstring("Normal BucketCreated")))
+
+			By("updating the spec with a maxSize quota")
+			Expect(k8sClient.Get(ctx, namespacedName(bucket.ObjectMeta), &bucket)).To(Succeed())
+			bucket.Spec.MaxSize = resource.MustParse("500Mi")
+			Expect(k8sClient.Update(ctx, &bucket)).To(Succeed())
+
+			By("reconciling to apply the quota update")
+			_, err = sut.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName(bucket.ObjectMeta)})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("emitting no further events")
+			Consistently(rec.Events).ShouldNot(Receive())
 		})
 
 		It("recovers from conflict once configMapName is set", func() {
@@ -691,7 +754,7 @@ func shouldReconcile(controller *BucketReconciler, obj metav1.ObjectMeta) {
 func setupBucket() (*BucketReconciler, *s3APIFake, *permissionClientFake) {
 	s3API := newS3APIFake()
 	perm := newPermissionClientFake()
-	sut := NewBucketReconciler(k8sClient, k8sClient.Scheme(), s3API, "https://s3.foo/bar:123", perm)
+	sut := NewBucketReconciler(k8sClient, k8sClient.Scheme(), s3API, "https://s3.foo/bar:123", perm, record.NewFakeRecorder(10))
 	return sut, s3API, perm
 }
 

--- a/internal/controller/bucket_manager_test.go
+++ b/internal/controller/bucket_manager_test.go
@@ -61,7 +61,14 @@ var _ = Describe("Bucket controller manager", Ordered, func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		r := NewBucketReconciler(mgr.GetClient(), mgr.GetScheme(), s3Fake, "http://s3.bar.com", permissionsClient)
+		r := NewBucketReconciler(
+			mgr.GetClient(),
+			mgr.GetScheme(),
+			s3Fake,
+			"http://s3.bar.com",
+			permissionsClient,
+			mgr.GetEventRecorderFor("garage-bucket-controller"),
+		)
 		r.baseRequeueInterval = time.Second
 		Expect(r.SetupWithManager(mgr)).To(Succeed())
 

--- a/internal/controller/reasons.go
+++ b/internal/controller/reasons.go
@@ -1,0 +1,3 @@
+package controller
+
+const ReasonBucketCreated = "BucketCreated" // type Normal: new bucket in Garage

--- a/internal/controller/reasons.go
+++ b/internal/controller/reasons.go
@@ -1,3 +1,5 @@
 package controller
 
 const ReasonBucketCreated = "BucketCreated" // type Normal: new bucket in Garage
+
+const ReasonBucketCreateFailed = "BucketCreateFailed" // type Warning: bucket creation in Garage failed


### PR DESCRIPTION
Emit events related to bucket creation to indicate a success or failure. A normal event is emitted only during the initial bucket creation.

Related to #96 