### PR TITLE
feat(controller): Add admin API request metrics

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -190,9 +191,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	garage.RegisterMetrics()
+	garageMetrics := garage.NewMetrics()
+	crmetrics.Registry.MustRegister(garageMetrics.Collectors()...)
 
-	garageClient := garage.NewClient(cfg.garageAPIEndpoint, cfg.garageAPIToken)
+	garageClient := garage.NewClient(
+		cfg.garageAPIEndpoint,
+		cfg.garageAPIToken,
+		garage.WithMetrics(garageMetrics),
+	)
 	if err := controller.NewBucketReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -190,6 +190,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	garage.RegisterMetrics()
+
 	garageClient := garage.NewClient(cfg.garageAPIEndpoint, cfg.garageAPIToken)
 	if err := controller.NewBucketReconciler(
 		mgr.GetClient(),

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.27.3
 	github.com/onsi/gomega v1.38.3
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/testcontainers/testcontainers-go v0.41.0
 	k8s.io/api v0.34.3
 	k8s.io/apimachinery v0.34.3
@@ -71,6 +73,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -89,8 +92,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.2 // indirect

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/bmarinov/garage-storage-controller/internal/s3"
 )
@@ -31,6 +32,7 @@ type AdminClient struct {
 	*BucketClient
 	*AccessKeyClient
 	*PermissionClient
+	*ClusterClient
 }
 
 func NewClient(apiAddr string, token string) *AdminClient {
@@ -44,6 +46,9 @@ func NewClient(apiAddr string, token string) *AdminClient {
 		&baseClient,
 	}
 	return &AdminClient{
+		ClusterClient: &ClusterClient{
+			&baseClient,
+		},
 		BucketClient: &BucketClient{
 			&baseClient,
 		},
@@ -53,6 +58,10 @@ func NewClient(apiAddr string, token string) *AdminClient {
 			accessKeys:         keyClient,
 		},
 	}
+}
+
+type ClusterClient struct {
+	*adminAPIHttpClient
 }
 
 type AccessKeyClient struct {
@@ -417,7 +426,54 @@ type adminAPIHttpClient struct {
 	baseURL    string
 }
 
+// Health performs an authenticated GET against the admin API.
+// Returns nil error when the response is 2xx.
+func (a *AdminClient) Health(ctx context.Context) error {
+	return a.ClusterClient.health(ctx)
+}
+
+func (c *adminAPIHttpClient) health(ctx context.Context) error {
+	const path = "/v2/GetClusterHealth"
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil, nil)
+	if err != nil {
+		return fmt.Errorf("garage admin api health: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		switch resp.StatusCode {
+		case http.StatusForbidden:
+			return fmt.Errorf("admin api healthcheck: forbidden %d", resp.StatusCode)
+		default:
+			return fmt.Errorf("garage admin api health: unexpected status code %d", resp.StatusCode)
+		}
+	}
+	return nil
+}
+
+// doRequest performs an admin API call and records request metrics.
 func (c *adminAPIHttpClient) doRequest(ctx context.Context,
+	method string,
+	path string,
+	queryParams *url.Values,
+	body io.Reader,
+) (*http.Response, error) {
+	start := time.Now()
+
+	resp, err := c.send(ctx, method, path, queryParams, body)
+
+	apiRequestDuration.Observe(time.Since(start).Seconds())
+	code := codeError
+	if err == nil && resp != nil {
+		code = statusClass(resp.StatusCode)
+	}
+	apiRequests.WithLabelValues(code).Inc()
+
+	return resp, err
+}
+
+func (c *adminAPIHttpClient) send(ctx context.Context,
 	method string,
 	path string,
 	queryParams *url.Values,

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -35,11 +35,23 @@ type AdminClient struct {
 	*ClusterClient
 }
 
-func NewClient(apiAddr string, token string) *AdminClient {
+// Option configures an AdminClient at construction.
+type Option func(*adminAPIHttpClient)
+
+// WithMetrics makes the client record request metrics into m. Without it the
+// client records nothing.
+func WithMetrics(m *Metrics) Option {
+	return func(c *adminAPIHttpClient) { c.metrics = m }
+}
+
+func NewClient(apiAddr string, token string, opts ...Option) *AdminClient {
 	baseClient := adminAPIHttpClient{
 		httpClient: &http.Client{},
 		token:      token,
 		baseURL:    apiAddr,
+	}
+	for _, opt := range opts {
+		opt(&baseClient)
 	}
 
 	keyClient := &AccessKeyClient{
@@ -424,6 +436,7 @@ type adminAPIHttpClient struct {
 	httpClient *http.Client
 	token      string
 	baseURL    string
+	metrics    *Metrics
 }
 
 // Health performs an authenticated GET against the admin API.
@@ -463,12 +476,13 @@ func (c *adminAPIHttpClient) doRequest(ctx context.Context,
 
 	resp, err := c.send(ctx, method, path, queryParams, body)
 
-	apiRequestDuration.Observe(time.Since(start).Seconds())
-	code := codeError
-	if err == nil && resp != nil {
-		code = statusClass(resp.StatusCode)
+	if c.metrics != nil {
+		code := codeError
+		if err == nil && resp != nil {
+			code = statusClass(resp.StatusCode)
+		}
+		c.metrics.record(code, time.Since(start))
 	}
-	apiRequests.WithLabelValues(code).Inc()
 
 	return resp, err
 }

--- a/internal/garage/client_test.go
+++ b/internal/garage/client_test.go
@@ -38,6 +38,29 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
+func TestHealthCheck(t *testing.T) {
+	t.Run("authenticated against a running Garage instance", func(t *testing.T) {
+		sut := NewClient(garageEnv.AdminAPIAddr, garageEnv.APIToken)
+		if err := sut.Health(t.Context()); err != nil {
+			t.Fatalf("expected healthy garage, got %v", err)
+		}
+	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		sut := NewClient(garageEnv.AdminAPIAddr, "not-a-valid-token")
+		if err := sut.Health(t.Context()); err == nil {
+			t.Fatal("expected error for invalid token")
+		}
+	})
+
+	t.Run("admin API is unreachable", func(t *testing.T) {
+		sut := NewClient("http://127.0.0.1:1", garageEnv.APIToken)
+		if err := sut.Health(t.Context()); err == nil {
+			t.Fatal("expected error for unreachable endpoint")
+		}
+	})
+}
+
 func TestBucketClient(t *testing.T) {
 	sut := NewClient(garageEnv.AdminAPIAddr, garageEnv.APIToken).BucketClient
 

--- a/internal/garage/metrics.go
+++ b/internal/garage/metrics.go
@@ -15,24 +15,45 @@
 package garage
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
-	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-var (
-	apiRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "garage_admin_api_requests_total",
-		Help: "Total Garage admin API requests by response status class (2xx/4xx/5xx or error).",
-	}, []string{"code"})
+// Metrics holds the Garage admin API metrics for a single client.
+// Construct with NewMetrics and register Collectors() with the Prometheus registry.
+//
+// Pass instance to NewClient via WithMetrics to start recording.
+type Metrics struct {
+	requests *prometheus.CounterVec
+	duration prometheus.Histogram
+}
 
-	apiRequestDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "garage_admin_api_request_duration_seconds",
-		Help:    "Duration of Garage admin API requests in seconds.",
-		Buckets: prometheus.DefBuckets,
-	})
-)
+func NewMetrics() *Metrics {
+	return &Metrics{
+		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "garage_admin_api_requests_total",
+			Help: "Total Garage admin API requests by response status class (2xx/4xx/5xx or error).",
+		}, []string{"code"}),
+		duration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "garage_admin_api_request_duration_seconds",
+			Help:    "Duration of Garage admin API requests in seconds.",
+			Buckets: prometheus.DefBuckets,
+		}),
+	}
+}
 
-// Values for the "code" label on apiRequests
+// Collectors returns the metrics to register with a Prometheus registry.
+func (m *Metrics) Collectors() []prometheus.Collector {
+	return []prometheus.Collector{m.requests, m.duration}
+}
+
+func (m *Metrics) record(code string, d time.Duration) {
+	m.duration.Observe(d.Seconds())
+	m.requests.WithLabelValues(code).Inc()
+}
+
+// Values for the "code" label on requests
 const (
 	codeHTTP2xx = "2xx"
 	codeHTTP3xx = "3xx"
@@ -40,18 +61,6 @@ const (
 	codeHTTP5xx = "5xx"
 	codeError   = "error"
 )
-
-// collectors lists every metric exposed by this package.
-var collectors = []prometheus.Collector{apiRequests, apiRequestDuration}
-
-// RegisterMetrics registers the Garage admin API metrics with the
-// controller-runtime registry.
-// Call exactly once during startup or MustRegister will panic.
-func RegisterMetrics() {
-	// TODO: sync once?;
-	// TODO: garage client package is now tied to controller-runtime, improve.
-	crmetrics.Registry.MustRegister(collectors...)
-}
 
 // statusClass maps an HTTP status code to a low cardinality label.
 func statusClass(code int) string {

--- a/internal/garage/metrics.go
+++ b/internal/garage/metrics.go
@@ -1,0 +1,68 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garage
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	apiRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "garage_admin_api_requests_total",
+		Help: "Total Garage admin API requests by response status class (2xx/4xx/5xx or error).",
+	}, []string{"code"})
+
+	apiRequestDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "garage_admin_api_request_duration_seconds",
+		Help:    "Duration of Garage admin API requests in seconds.",
+		Buckets: prometheus.DefBuckets,
+	})
+)
+
+// Values for the "code" label on apiRequests
+const (
+	codeHTTP2xx = "2xx"
+	codeHTTP3xx = "3xx"
+	codeHTTP4xx = "4xx"
+	codeHTTP5xx = "5xx"
+	codeError   = "error"
+)
+
+// collectors lists every metric exposed by this package.
+var collectors = []prometheus.Collector{apiRequests, apiRequestDuration}
+
+// RegisterMetrics registers the Garage admin API metrics with the
+// controller-runtime registry.
+// Call exactly once during startup or MustRegister will panic.
+func RegisterMetrics() {
+	// TODO: sync once?;
+	// TODO: garage client package is now tied to controller-runtime, improve.
+	crmetrics.Registry.MustRegister(collectors...)
+}
+
+// statusClass maps an HTTP status code to a low cardinality label.
+func statusClass(code int) string {
+	switch {
+	case code >= 200 && code < 300:
+		return codeHTTP2xx
+	case code >= 300 && code < 400:
+		return codeHTTP3xx
+	case code >= 400 && code < 500:
+		return codeHTTP4xx
+	default:
+		return codeHTTP5xx
+	}
+}

--- a/internal/garage/metrics_test.go
+++ b/internal/garage/metrics_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
-	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 func TestDoRequestMetrics(t *testing.T) {
@@ -38,14 +37,14 @@ func TestDoRequestMetrics(t *testing.T) {
 		}
 		for _, tc := range testCases {
 			t.Run(tc.statusCodeBucket, func(t *testing.T) {
-				apiRequests.Reset()
+				m := NewMetrics()
 
 				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					w.WriteHeader(tc.status)
 				}))
 				defer srv.Close()
 
-				err := NewClient(srv.URL, "token").Health(t.Context())
+				err := NewClient(srv.URL, "token", WithMetrics(m)).Health(t.Context())
 				if tc.wantErr && err == nil {
 					t.Fatal("expected error, got nil")
 				}
@@ -53,7 +52,7 @@ func TestDoRequestMetrics(t *testing.T) {
 					t.Fatalf("unexpected error: %v", err)
 				}
 
-				got := testutil.ToFloat64(apiRequests.WithLabelValues(tc.statusCodeBucket))
+				got := testutil.ToFloat64(m.requests.WithLabelValues(tc.statusCodeBucket))
 				if got != 1 {
 					t.Errorf("requests{code=%s} = %v, expected 1", tc.statusCodeBucket, got)
 				}
@@ -62,32 +61,44 @@ func TestDoRequestMetrics(t *testing.T) {
 	})
 
 	t.Run("counts transport failures as error", func(t *testing.T) {
-		apiRequests.Reset()
+		m := NewMetrics()
 
 		// :1 is reserved and causes a transport error:
-		err := NewClient("http://127.0.0.1:1", "token").Health(t.Context())
+		err := NewClient("http://127.0.0.1:1", "token", WithMetrics(m)).Health(t.Context())
 		if err == nil {
 			t.Fatal("expected transport error, got nil")
 		}
 
-		got := testutil.ToFloat64(apiRequests.WithLabelValues(codeError))
+		got := testutil.ToFloat64(m.requests.WithLabelValues(codeError))
 		if got != 1 {
 			t.Errorf("requests{code=error} = %v, expected 1", got)
 		}
 	})
 
 	t.Run("records request duration", func(t *testing.T) {
+		m := NewMetrics()
+
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
 		defer srv.Close()
 
-		before := histogramSampleCount(t, apiRequestDuration)
-		if err := NewClient(srv.URL, "token").Health(t.Context()); err != nil {
+		if err := NewClient(srv.URL, "token", WithMetrics(m)).Health(t.Context()); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if after := histogramSampleCount(t, apiRequestDuration); after <= before {
-			t.Errorf("duration sample count = %d, expected > %d", after, before)
+		if got := histogramSampleCount(t, m.duration); got != 1 {
+			t.Errorf("duration sample count = %d, expected 1", got)
+		}
+	})
+
+	t.Run("a client without metrics records nothing and does not panic", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		if err := NewClient(srv.URL, "token").Health(t.Context()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }
@@ -101,23 +112,26 @@ func histogramSampleCount(t *testing.T, h prometheus.Histogram) uint64 {
 	return m.GetHistogram().GetSampleCount()
 }
 
-func TestRegisterMetrics(t *testing.T) {
-	RegisterMetrics()
+func TestMetricsCollectors(t *testing.T) {
+	m := NewMetrics()
 
-	apiRequestDuration.Observe(0.01)
+	m.duration.Observe(0.01)
 	// no series exposed until a label is observed:
-	apiRequests.WithLabelValues(codeHTTP2xx).Inc()
+	m.requests.WithLabelValues(codeHTTP2xx).Inc()
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(m.Collectors()...)
 
 	for _, name := range []string{
 		"garage_admin_api_requests_total",
 		"garage_admin_api_request_duration_seconds",
 	} {
-		count, err := testutil.GatherAndCount(crmetrics.Registry, name)
+		count, err := testutil.GatherAndCount(reg, name)
 		if err != nil {
 			t.Fatalf("gathering %s: %v", name, err)
 		}
 		if count == 0 {
-			t.Errorf("%s not registered on the controller-runtime registry", name)
+			t.Errorf("%s not registered", name)
 		}
 	}
 }

--- a/internal/garage/metrics_test.go
+++ b/internal/garage/metrics_test.go
@@ -1,0 +1,123 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garage
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func TestDoRequestMetrics(t *testing.T) {
+	t.Run("counts requests by status class", func(t *testing.T) {
+		testCases := []struct {
+			statusCodeBucket string
+			status           int
+			wantErr          bool
+		}{
+			{codeHTTP2xx, http.StatusOK, false},
+			{codeHTTP4xx, http.StatusNotFound, true},
+			{codeHTTP5xx, http.StatusInternalServerError, true},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.statusCodeBucket, func(t *testing.T) {
+				apiRequests.Reset()
+
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(tc.status)
+				}))
+				defer srv.Close()
+
+				err := NewClient(srv.URL, "token").Health(t.Context())
+				if tc.wantErr && err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !tc.wantErr && err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				got := testutil.ToFloat64(apiRequests.WithLabelValues(tc.statusCodeBucket))
+				if got != 1 {
+					t.Errorf("requests{code=%s} = %v, expected 1", tc.statusCodeBucket, got)
+				}
+			})
+		}
+	})
+
+	t.Run("counts transport failures as error", func(t *testing.T) {
+		apiRequests.Reset()
+
+		// :1 is reserved and causes a transport error:
+		err := NewClient("http://127.0.0.1:1", "token").Health(t.Context())
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+
+		got := testutil.ToFloat64(apiRequests.WithLabelValues(codeError))
+		if got != 1 {
+			t.Errorf("requests{code=error} = %v, expected 1", got)
+		}
+	})
+
+	t.Run("records request duration", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		before := histogramSampleCount(t, apiRequestDuration)
+		if err := NewClient(srv.URL, "token").Health(t.Context()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if after := histogramSampleCount(t, apiRequestDuration); after <= before {
+			t.Errorf("duration sample count = %d, expected > %d", after, before)
+		}
+	})
+}
+
+func histogramSampleCount(t *testing.T, h prometheus.Histogram) uint64 {
+	t.Helper()
+	var m dto.Metric
+	if err := h.Write(&m); err != nil {
+		t.Fatalf("writing histogram metric: %v", err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}
+
+func TestRegisterMetrics(t *testing.T) {
+	RegisterMetrics()
+
+	apiRequestDuration.Observe(0.01)
+	// no series exposed until a label is observed:
+	apiRequests.WithLabelValues(codeHTTP2xx).Inc()
+
+	for _, name := range []string{
+		"garage_admin_api_requests_total",
+		"garage_admin_api_request_duration_seconds",
+	} {
+		count, err := testutil.GatherAndCount(crmetrics.Registry, name)
+		if err != nil {
+			t.Fatalf("gathering %s: %v", name, err)
+		}
+		if count == 0 {
+			t.Errorf("%s not registered on the controller-runtime registry", name)
+		}
+	}
+}


### PR DESCRIPTION
Adds  metrics for the Garage admin API client:
- `garage_admin_api_requests_total`: admin API requests by response status
- `garage_admin_api_request_duration_seconds`: duration histogram

Adds a new client method for health requests against `/v2/GetClusterHealth` for a follow-up PR.

Related to #32 
