### PR TITLE
feat(controller): add admin token preflight check at startup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,9 +15,11 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"os"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -39,6 +41,7 @@ import (
 	garagev1alpha1 "github.com/bmarinov/garage-storage-controller/api/v1alpha1"
 	"github.com/bmarinov/garage-storage-controller/internal/controller"
 	"github.com/bmarinov/garage-storage-controller/internal/garage"
+	"github.com/bmarinov/garage-storage-controller/internal/health"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -199,6 +202,13 @@ func main() {
 		cfg.garageAPIToken,
 		garage.WithMetrics(garageMetrics),
 	)
+
+	signalCtx := ctrl.SetupSignalHandler()
+
+	preflightCtx, cancel := context.WithTimeout(signalCtx, 10*time.Second)
+	defer cancel()
+	health.PreflightCheck(preflightCtx, garageClient)
+
 	if err := controller.NewBucketReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
@@ -237,7 +247,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(signalCtx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/internal/garage/api_types.go
+++ b/internal/garage/api_types.go
@@ -16,6 +16,14 @@ package garage
 
 import "github.com/bmarinov/garage-storage-controller/internal/s3"
 
+// AdminTokenInfo is the response from GetCurrentAdminTokenInfo.
+type AdminTokenInfo struct {
+	Name       string   `json:"name"`
+	Expired    bool     `json:"expired"`
+	Scope      []string `json:"scope"`
+	Expiration *string  `json:"expiration"`
+}
+
 type BucketUpdateRequest struct {
 	Quotas Quotas `json:"quotas"`
 }

--- a/internal/garage/client.go
+++ b/internal/garage/client.go
@@ -76,6 +76,50 @@ type ClusterClient struct {
 	*adminAPIHttpClient
 }
 
+// Health reports whether the admin API is reachable via GET against GetClusterHealth.
+//
+// Returns nil when the response is 2xx.
+func (c *ClusterClient) Health(ctx context.Context) error {
+	const path = "/v2/GetClusterHealth"
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil, nil)
+	if err != nil {
+		return fmt.Errorf("garage admin api health: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		switch resp.StatusCode {
+		case http.StatusForbidden:
+			return fmt.Errorf("garage admin api health: forbidden (status %d)", resp.StatusCode)
+		default:
+			return fmt.Errorf("garage admin api health: unexpected status code %d", resp.StatusCode)
+		}
+	}
+	return nil
+}
+
+// CurrentTokenInfo returns the admin token the client authenticates with.
+func (c *ClusterClient) CurrentTokenInfo(ctx context.Context) (AdminTokenInfo, error) {
+	const path = "/v2/GetCurrentAdminTokenInfo"
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil, nil)
+	if err != nil {
+		return AdminTokenInfo{}, fmt.Errorf("garage admin token info: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		switch resp.StatusCode {
+		case http.StatusForbidden:
+			return AdminTokenInfo{}, fmt.Errorf("garage admin token info: token rejected (status %d)", resp.StatusCode)
+		default:
+			return AdminTokenInfo{}, fmt.Errorf("garage admin token info: unexpected status code %d", resp.StatusCode)
+		}
+	}
+	return unmarshalBody[AdminTokenInfo](resp.Body)
+}
+
 type AccessKeyClient struct {
 	*adminAPIHttpClient
 }
@@ -439,33 +483,7 @@ type adminAPIHttpClient struct {
 	metrics    *Metrics
 }
 
-// Health performs an authenticated GET against the admin API.
-// Returns nil error when the response is 2xx.
-func (a *AdminClient) Health(ctx context.Context) error {
-	return a.ClusterClient.health(ctx)
-}
-
-func (c *adminAPIHttpClient) health(ctx context.Context) error {
-	const path = "/v2/GetClusterHealth"
-	resp, err := c.doRequest(ctx, http.MethodGet, path, nil, nil)
-	if err != nil {
-		return fmt.Errorf("garage admin api health: %w", err)
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-	if resp.StatusCode != http.StatusOK {
-		switch resp.StatusCode {
-		case http.StatusForbidden:
-			return fmt.Errorf("admin api healthcheck: forbidden %d", resp.StatusCode)
-		default:
-			return fmt.Errorf("garage admin api health: unexpected status code %d", resp.StatusCode)
-		}
-	}
-	return nil
-}
-
-// doRequest performs an admin API call and records request metrics.
+// doRequest performs an admin API call and records request metrics when enabled.
 func (c *adminAPIHttpClient) doRequest(ctx context.Context,
 	method string,
 	path string,

--- a/internal/garage/client_test.go
+++ b/internal/garage/client_test.go
@@ -47,7 +47,7 @@ func TestHealthCheck(t *testing.T) {
 	})
 
 	t.Run("invalid token", func(t *testing.T) {
-		sut := NewClient(garageEnv.AdminAPIAddr, "not-a-valid-token")
+		sut := NewClient(garageEnv.AdminAPIAddr, "not-a-token")
 		if err := sut.Health(t.Context()); err == nil {
 			t.Fatal("expected error for invalid token")
 		}
@@ -57,6 +57,41 @@ func TestHealthCheck(t *testing.T) {
 		sut := NewClient("http://127.0.0.1:1", garageEnv.APIToken)
 		if err := sut.Health(t.Context()); err == nil {
 			t.Fatal("expected error for unreachable endpoint")
+		}
+	})
+}
+
+func TestCurrentTokenInfo(t *testing.T) {
+	t.Run("valid token returns usable info", func(t *testing.T) {
+		sut := NewClient(garageEnv.AdminAPIAddr, garageEnv.APIToken)
+		info, err := sut.CurrentTokenInfo(t.Context())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if info.Expired {
+			t.Error("expected a non-expired token")
+		}
+		if info.Name == "" {
+			t.Error("expected a token name")
+		}
+		if len(info.Scope) == 0 {
+			t.Error("expected at least one scope")
+		}
+	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		sut := NewClient(garageEnv.AdminAPIAddr, fixture.RandAlpha(20))
+		_, err := sut.CurrentTokenInfo(t.Context())
+		if err == nil {
+			t.Fatal("expected error for invalid token")
+		}
+	})
+
+	t.Run("admin API is unreachable", func(t *testing.T) {
+		sut := NewClient("http://127.0.0.1:1", garageEnv.APIToken)
+		_, err := sut.CurrentTokenInfo(t.Context())
+		if err == nil {
+			t.Fatal("expected error when unreachable")
 		}
 	})
 }

--- a/internal/health/preflight.go
+++ b/internal/health/preflight.go
@@ -1,0 +1,49 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"context"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/bmarinov/garage-storage-controller/internal/garage"
+)
+
+type GarageAdminAuth interface {
+	CurrentTokenInfo(ctx context.Context) (garage.AdminTokenInfo, error)
+}
+
+// PreflightCheck logs the result of a one-time admin token check at startup.
+// It never returns an error or cause the controller to exit.
+func PreflightCheck(ctx context.Context, garageAdm GarageAdminAuth) {
+	log := logf.FromContext(ctx).WithName("preflight")
+	info, err := garageAdm.CurrentTokenInfo(ctx)
+	switch {
+	case err != nil:
+		log.Error(err, "garage admin API preflight failed, starting anyway; "+
+			"check GARAGE_API_ENDPOINT / GARAGE_API_TOKEN")
+	case info.Expired:
+		log.Info("garage admin API reachable but token EXPIRED",
+			"token", info.Name, "expiration", info.Expiration)
+	default:
+		kv := []any{"token", info.Name}
+		if info.Expiration != nil {
+			kv = append(kv, "expiration", *info.Expiration)
+		}
+		kv = append(kv, "scopes", info.Scope)
+		log.Info("garage admin API reachable, token accepted", kv...)
+	}
+}

--- a/internal/health/preflight.go
+++ b/internal/health/preflight.go
@@ -33,8 +33,8 @@ func PreflightCheck(ctx context.Context, garageAdm GarageAdminAuth) {
 	info, err := garageAdm.CurrentTokenInfo(ctx)
 	switch {
 	case err != nil:
-		log.Error(err, "garage admin API preflight failed, starting anyway; "+
-			"check GARAGE_API_ENDPOINT / GARAGE_API_TOKEN")
+		log.Info("garage admin API preflight failed, starting anyway; "+
+			"check GARAGE_API_ENDPOINT / GARAGE_API_TOKEN", "error", err)
 	case info.Expired:
 		log.Info("garage admin API reachable but token EXPIRED",
 			"token", info.Name, "expiration", info.Expiration)


### PR DESCRIPTION
Run a check against the admin API on startup. Checks for general connectivity issues, token validity and expiration.

Resolves #102