### PR TITLE
refactor(metrics): move admin API metrics under garage_controller namespace

### DIFF
--- a/internal/garage/metrics.go
+++ b/internal/garage/metrics.go
@@ -29,17 +29,29 @@ type Metrics struct {
 	duration prometheus.Histogram
 }
 
+const (
+	metricsNamespace = "garage_controller"
+	metricsSubsystem = "admin_api"
+)
+
 func NewMetrics() *Metrics {
 	return &Metrics{
-		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "garage_admin_api_requests_total",
-			Help: "Total Garage admin API requests by response status class (2xx/4xx/5xx or error).",
-		}, []string{"code"}),
-		duration: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:    "garage_admin_api_request_duration_seconds",
-			Help:    "Duration of Garage admin API requests in seconds.",
-			Buckets: prometheus.DefBuckets,
-		}),
+		requests: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
+				Name:      "requests_total",
+				Help:      "Total Garage admin API requests by response status class (2xx/4xx/5xx or error).",
+			},
+			[]string{"status_class"}),
+		duration: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
+				Name:      "request_duration_seconds",
+				Help:      "Duration of Garage admin API requests in seconds.",
+				Buckets:   prometheus.DefBuckets,
+			}),
 	}
 }
 
@@ -53,7 +65,7 @@ func (m *Metrics) record(code string, d time.Duration) {
 	m.requests.WithLabelValues(code).Inc()
 }
 
-// Values for the "code" label on requests
+// Values for the "status_class" label on requests
 const (
 	codeHTTP2xx = "2xx"
 	codeHTTP3xx = "3xx"

--- a/internal/garage/metrics_test.go
+++ b/internal/garage/metrics_test.go
@@ -123,8 +123,8 @@ func TestMetricsCollectors(t *testing.T) {
 	reg.MustRegister(m.Collectors()...)
 
 	for _, name := range []string{
-		"garage_admin_api_requests_total",
-		"garage_admin_api_request_duration_seconds",
+		"garage_controller_admin_api_requests_total",
+		"garage_controller_admin_api_request_duration_seconds",
 	} {
 		count, err := testutil.GatherAndCount(reg, name)
 		if err != nil {


### PR DESCRIPTION
Scope the metric names to the controller to avoid colliding with Garage's own server-side metrics.

  `garage_admin_api_requests_total` -> `garage_controller_admin_api_requests_total`
  `garage_admin_api_request_duration_seconds` -> `garage_controller_admin_api_request_duration_seconds`

