### PR TITLE
feat(controller): Add Garage admin API connectivity heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,25 @@ See [config/rbac/base/role_namespace_access.yaml](config/rbac/namespaces/base/ro
 
 **Note**: The controller does not need cluster-wide access to ConfigMaps or Secrets. Use namespace roles.
 
+# Observability
+
+## Metrics
+The controller exposes Prometheus metrics for its Garage admin API dependency:
+
+| Metric | Type | Description |
+|---|---|---|
+| `garage_controller_admin_api_up` | Gauge | `1` when the Garage admin API is reachable, `0` otherwise. On a 30s refresh. |
+| `garage_controller_admin_api_requests_total` | Counter | Admin API requests; labels: `status_class` (`2xx`/`3xx`/`4xx`/`5xx` or `error`). |
+| `garage_controller_admin_api_request_duration_seconds` | Histogram | Admin API request latency in seconds. |
+
+## Logs
+
+Logs follow controller-runtime conventions, using info and error levels.
+
+Relevant for operations:
+- Preflight check logged on startup (config validation and auth).
+- Garage connectivity loss logs at `Error` and recovery at `Info`.
+
 # Development
 
 ## Project setup

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -246,6 +246,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	go health.Run(signalCtx, garageClient, garageMetrics.SetAPIUp, 30*time.Second)
+
 	setupLog.Info("starting manager")
 	if err := mgr.Start(signalCtx); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/internal/garage/metrics.go
+++ b/internal/garage/metrics.go
@@ -68,9 +68,9 @@ func (m *Metrics) Collectors() []prometheus.Collector {
 	return []prometheus.Collector{m.requests, m.duration, m.up}
 }
 
-// SetUp records whether the Garage admin API is currently reachable.
-func (m *Metrics) SetUp(ok bool) {
-	if ok {
+// SetAPIUp records whether the Garage admin API is currently reachable.
+func (m *Metrics) SetAPIUp(isUp bool) {
+	if isUp {
 		m.up.Set(1)
 		return
 	}

--- a/internal/garage/metrics.go
+++ b/internal/garage/metrics.go
@@ -27,6 +27,7 @@ import (
 type Metrics struct {
 	requests *prometheus.CounterVec
 	duration prometheus.Histogram
+	up       prometheus.Gauge
 }
 
 const (
@@ -52,12 +53,28 @@ func NewMetrics() *Metrics {
 				Help:      "Duration of Garage admin API requests in seconds.",
 				Buckets:   prometheus.DefBuckets,
 			}),
+		up: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
+				Name:      "up",
+				Help:      "Gauge for the Garage admin API: 1 reachable, 0 not.",
+			}),
 	}
 }
 
 // Collectors returns the metrics to register with a Prometheus registry.
 func (m *Metrics) Collectors() []prometheus.Collector {
-	return []prometheus.Collector{m.requests, m.duration}
+	return []prometheus.Collector{m.requests, m.duration, m.up}
+}
+
+// SetUp records whether the Garage admin API is currently reachable.
+func (m *Metrics) SetUp(ok bool) {
+	if ok {
+		m.up.Set(1)
+		return
+	}
+	m.up.Set(0)
 }
 
 func (m *Metrics) record(code string, d time.Duration) {

--- a/internal/garage/metrics_test.go
+++ b/internal/garage/metrics_test.go
@@ -112,6 +112,26 @@ func histogramSampleCount(t *testing.T, h prometheus.Histogram) uint64 {
 	return m.GetHistogram().GetSampleCount()
 }
 
+func TestSetUp(t *testing.T) {
+	testCases := []struct {
+		name string
+		ok   bool
+		want float64
+	}{
+		{"reachable sets gauge to 1", true, 1},
+		{"unreachable sets 0", false, 0},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewMetrics()
+			m.SetUp(tc.ok)
+			if got := testutil.ToFloat64(m.up); got != tc.want {
+				t.Errorf("up = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestMetricsCollectors(t *testing.T) {
 	m := NewMetrics()
 
@@ -125,6 +145,7 @@ func TestMetricsCollectors(t *testing.T) {
 	for _, name := range []string{
 		"garage_controller_admin_api_requests_total",
 		"garage_controller_admin_api_request_duration_seconds",
+		"garage_controller_admin_api_up",
 	} {
 		count, err := testutil.GatherAndCount(reg, name)
 		if err != nil {

--- a/internal/garage/metrics_test.go
+++ b/internal/garage/metrics_test.go
@@ -112,11 +112,11 @@ func histogramSampleCount(t *testing.T, h prometheus.Histogram) uint64 {
 	return m.GetHistogram().GetSampleCount()
 }
 
-func TestSetUp(t *testing.T) {
+func TestSetAPIUp(t *testing.T) {
 	testCases := []struct {
-		name string
-		ok   bool
-		want float64
+		name     string
+		ok       bool
+		expected float64
 	}{
 		{"reachable sets gauge to 1", true, 1},
 		{"unreachable sets 0", false, 0},
@@ -124,9 +124,9 @@ func TestSetUp(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			m := NewMetrics()
-			m.SetUp(tc.ok)
-			if got := testutil.ToFloat64(m.up); got != tc.want {
-				t.Errorf("up = %v, want %v", got, tc.want)
+			m.SetAPIUp(tc.ok)
+			if got := testutil.ToFloat64(m.up); got != tc.expected {
+				t.Errorf("expected up %v, got %v", tc.expected, got)
 			}
 		})
 	}

--- a/internal/health/heartbeat.go
+++ b/internal/health/heartbeat.go
@@ -1,0 +1,86 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"context"
+	"time"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// HealthChecker for the Garage admin API.
+type HealthChecker interface {
+	Health(ctx context.Context) error
+}
+
+// UpRecorder stores the latest healthcheck result.
+type UpRecorder func(isUp bool)
+
+// defaultInterval is used when a non-positive interval is passed.
+const defaultInterval = 30 * time.Second
+
+// Run polls the Garage admin API every interval, reporting each result to record.
+//
+// Blocks until ctx is cancelled.
+//
+// When interval is <= 0, the default of 30s is used.
+func Run(ctx context.Context, checker HealthChecker, record UpRecorder, interval time.Duration) {
+	if interval <= 0 {
+		interval = defaultInterval
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	run(ctx, checker, record, interval, t.C)
+}
+
+// run the heartbeat loop with an injected tick source.
+func run(ctx context.Context,
+	checker HealthChecker,
+	record UpRecorder,
+	timeout time.Duration,
+	ticks <-chan time.Time,
+) {
+	log := logf.FromContext(ctx).WithName("heartbeat")
+
+	lastUp := true
+	for {
+		err := probe(ctx, checker, timeout)
+		isUp := err == nil
+		record(isUp)
+		if isUp != lastUp {
+			if isUp {
+				log.Info("garage admin API reachable")
+			} else {
+				log.Error(err, "garage admin API unreachable")
+			}
+		}
+		lastUp = isUp
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticks:
+		}
+	}
+}
+
+// probe limits a single healthcheck to a timeout.
+// The limit shold be lt or equal to the check interval.
+func probe(ctx context.Context, checker HealthChecker, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return checker.Health(ctx)
+}

--- a/internal/health/heartbeat_test.go
+++ b/internal/health/heartbeat_test.go
@@ -1,0 +1,131 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/go-logr/zapr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestRun(t *testing.T) {
+	t.Run("records every tick and logs only transitions", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		core, logs := observer.New(zap.InfoLevel)
+		ctx = logf.IntoContext(ctx, zapr.NewLogger(zap.New(core)))
+
+		checker := &fakeChecker{results: []error{nil, errors.New("boom"), nil}}
+		rec := &fakeRecorder{}
+
+		runAndWait(ctx, cancel, checker, rec.record, 2)
+
+		if expected := []bool{true, false, true}; !slices.Equal(rec.reachability, expected) {
+			t.Errorf("expected reachability %v, got %v", expected, rec.reachability)
+		}
+		// up -> down -> up = two transitions:
+		logCount := logs.Len()
+		if logCount != 2 {
+			t.Errorf("expected 2 log lines got %d", logCount)
+		}
+		errLogCount := logs.FilterLevelExact(zapcore.ErrorLevel).Len()
+		if errLogCount != 1 {
+			t.Errorf("expected 1 error-level log on conn loss got %d", errLogCount)
+		}
+		infoCount := logs.FilterLevelExact(zapcore.InfoLevel).Len()
+		if infoCount != 1 {
+			t.Errorf("expected 1 info log for the recovery, got %d", infoCount)
+		}
+	})
+
+	t.Run("passing zero interval", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		checker := &fakeChecker{results: []error{nil}, onLast: cancel}
+		rec := &fakeRecorder{}
+
+		Run(ctx, checker, rec.record, 0)
+
+		if len(rec.reachability) != 1 || !rec.reachability[0] {
+			t.Errorf("expected single true value got %v", rec.reachability)
+		}
+	})
+
+	t.Run("healthy steady state", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		core, logs := observer.New(zap.InfoLevel)
+		ctx = logf.IntoContext(ctx, zapr.NewLogger(zap.New(core)))
+
+		checker := &fakeChecker{results: []error{nil, nil, nil}}
+
+		runAndWait(ctx, cancel, checker, (&fakeRecorder{}).record, 2)
+
+		if logs.Len() != 0 {
+			t.Errorf("expected 0 log lines in steady state, got %d", logs.Len())
+		}
+	})
+}
+
+// runAndWait deterministically runs the heartbeat for 1 + tickCount operations.
+// Cancels and waits for run to return.
+func runAndWait(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	checker HealthChecker,
+	record UpRecorder,
+	tickCount int,
+) {
+	ticks := make(chan time.Time)
+	done := make(chan struct{})
+	go func() {
+		run(ctx, checker, record, time.Minute, ticks)
+		close(done)
+	}()
+	for range tickCount {
+		ticks <- time.Now()
+	}
+	cancel()
+	<-done
+}
+
+type fakeChecker struct {
+	results []error
+	i       int
+	onLast  func()
+}
+
+func (f *fakeChecker) Health(context.Context) error {
+	err := f.results[f.i]
+	f.i++
+	if f.i == len(f.results) && f.onLast != nil {
+		f.onLast()
+	}
+	return err
+}
+
+type fakeRecorder struct {
+	reachability []bool
+}
+
+func (f *fakeRecorder) record(isUp bool) {
+	f.reachability = append(f.reachability, isUp)
+}


### PR DESCRIPTION
Adds a background heartbeat that polls the Garage admin API every 30 seconds.

Exposes a new metric `garage_controller_admin_api_up` as a prom gauge. Logs connectivity transitions.

Fixes #108 
