### PR TITLE
fix(controller): key deletion when status ID is not persisted

### DIFF
--- a/internal/controller/accesskey_controller.go
+++ b/internal/controller/accesskey_controller.go
@@ -97,19 +97,23 @@ func (r *AccessKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	} else {
 		if controllerutil.ContainsFinalizer(&accessKey, finalizerName) {
-			err = r.accessKey.Delete(ctx, accessKey.Status.AccessKeyID)
-
-			if err != nil && !errors.Is(err, s3.ErrResourceNotFound) {
-				return ctrl.Result{}, err
-			}
-
-			_ = controllerutil.RemoveFinalizer(&accessKey, finalizerName)
-			err = r.client.Update(ctx, &accessKey)
+			id, err := r.resolveExtKeyID(ctx, accessKey)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
+			if id != "" {
+				err = r.accessKey.Delete(ctx, id)
+				if err != nil && !errors.Is(err, s3.ErrResourceNotFound) {
+					return ctrl.Result{}, err
+				}
+			}
+
+			_ = controllerutil.RemoveFinalizer(&accessKey, finalizerName)
+			if err = r.client.Update(ctx, &accessKey); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, nil
 	}
 
 	orig := accessKey.Status.DeepCopy()
@@ -203,6 +207,23 @@ func (r *AccessKeyReconciler) cleanupOldSecret(ctx context.Context, secretName, 
 		return fmt.Errorf("deleting secret '%s/%s': %w", namespace, secretName, err)
 	}
 	return nil
+}
+
+// resolveExtKeyID returns the external key ID to delete, or empty if not found.
+// The ID from the AccessKey status has priority.
+// Performs a lookup by name in case the key ID is not available.
+func (r *AccessKeyReconciler) resolveExtKeyID(ctx context.Context, resource garagev1alpha1.AccessKey) (string, error) {
+	if resource.Status.AccessKeyID != "" {
+		return resource.Status.AccessKeyID, nil
+	}
+	key, err := r.accessKey.Lookup(ctx, namespacedResourceName(resource.ObjectMeta))
+	if errors.Is(err, s3.ErrResourceNotFound) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("looking up key for deletion: %w", err)
+	}
+	return key.ID, nil
 }
 
 func (r *AccessKeyReconciler) ensureExternalKey(ctx context.Context, resource garagev1alpha1.AccessKey) (s3.AccessKey, error) {

--- a/internal/controller/accesskey_controller_test.go
+++ b/internal/controller/accesskey_controller_test.go
@@ -435,6 +435,49 @@ var _ = Describe("AccessKey Controller", func() {
 			err = k8sClient.Get(ctx, objID, &accessKey)
 			Expect(err).To(Satisfy(apierrors.IsNotFound))
 		})
+		It("deletes orphaned external key on a lost status write", func() {
+			sut, externalAPI := setup()
+
+			accessKey := garagev1alpha1.AccessKey{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fixture.RandAlpha(10),
+					Namespace: namespace,
+				},
+				Spec: garagev1alpha1.AccessKeySpec{
+					SecretName: fixture.RandAlpha(10),
+				},
+			}
+			Expect(k8sClient.Create(ctx, &accessKey)).To(Succeed())
+			objID := types.NamespacedName{Name: accessKey.Name, Namespace: accessKey.Namespace}
+
+			By("reconcile creates the garage key, finalizer and status")
+			_, err := sut.Reconcile(ctx, reconcile.Request{NamespacedName: objID})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(externalAPI.keys).To(HaveLen(1), "garage key created")
+
+			By("simulating a lost status write due to e.g. missing permissions (issue #110)")
+			Expect(k8sClient.Get(ctx, objID, &accessKey)).To(Succeed())
+			Expect(accessKey.Finalizers).To(ContainElement(finalizerName))
+			accessKey.Status.AccessKeyID = ""
+			Expect(k8sClient.Status().Update(ctx, &accessKey)).To(Succeed())
+
+			By("deleting AccessKey resource")
+			Expect(k8sClient.Delete(ctx, &accessKey)).To(Succeed())
+
+			Eventually(func(g Gomega) bool {
+				g.Expect(k8sClient.Get(ctx, objID, &accessKey)).To(Succeed())
+				return !accessKey.DeletionTimestamp.IsZero()
+			}).Should(BeTrue(), "resource should exist with deletion timestamp")
+
+			By("reconciling AccessKey")
+			_, err = sut.Reconcile(ctx, reconcile.Request{NamespacedName: objID})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Garage external key and k8s resource removed")
+			Expect(externalAPI.keys).To(BeEmpty(), "should not leave orphaned key in garage")
+			err = k8sClient.Get(ctx, objID, &accessKey)
+			Expect(err).To(Satisfy(apierrors.IsNotFound))
+		})
 		It("sets status when secret with name already exists", func() {
 			sut, _ := setup()
 


### PR DESCRIPTION
The controller got stuck during AccessKey deletion with unknown external key  ID. When Secret permissions are missing for a namespace, the key is created but its ID is never saved. 
When attempting to delete with an empty `Status.AccessKeyID`, Garage returns an HTTP400 which the controller failed to handle and the finalizer remained on the object.

Deletion falls back to a lookup by name so orphaned keys are cleaned up.

Fixes #110 