### PR TITLE
chore: Update Go to v1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.26.4 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.26.5 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26
 
 require (
 	github.com/docker/docker v28.5.2+incompatible
-	github.com/docker/go-connections v0.7.0
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.32.0
@@ -39,6 +38,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect

--- a/internal/controller/reasons.go
+++ b/internal/controller/reasons.go
@@ -1,3 +1,17 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package controller
 
 const ReasonBucketCreated = "BucketCreated" // type Normal: new bucket in Garage


### PR DESCRIPTION
Details: [golang/go milestone 1.26.5](https://github.com/golang/go/issues?q=milestone%3AGo1.26.5+label%3ACherryPickApproved) (bug fixes and CVEs).