### PR TITLE
chore(helm): Update release docs and improve helm manifest sync

### DIFF
--- a/.github/workflows/helm-pr.yml
+++ b/.github/workflows/helm-pr.yml
@@ -35,4 +35,4 @@ jobs:
         run: go test -tags chart ./test/chart/
 
       - name: Helm lint
-        run: helm lint chart/
+        run: helm lint chart/ --strict -f "chart/values.test.yaml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+Thanks for contributing. Run `make test` before you open a PR. Keep changes focused on one area and small enough to review in one sitting.
+
+`make test` already runs the code gen targets:
+- `make generate` generates DeepCopy methods (`zz_generated.deepcopy.go`) for the types in `api/v1alpha1`, and license headers.
+- `make manifests` writes YAML manifests into `config/` including the CRDs and the controller ClusterRole.
+
+## Chart changes
+
+App PRs must not touch `chart/**`. The chart is released separately from the app.
+
+Any change under `chart/` triggers a CI check that fails unless the chart version was bumped.
+
+## Releasing (maintainers)
+
+The app release is done first, and the chart follows in a separate PR. The chart cannot reference an unreleased app version.
+
+Process:
+- Merge the app PRs, tag the release (`make tag TAG=vx.y.z`).
+- Open a separate PR for the chart.
+- Bump `version` (and `appVersion`) in `chart/Chart.yaml`
+  - update the version table in `chart/README.md`.
+- Run `make helm-sync`.
+  - copies the CRDs
+  - runs helm lint
+  - checks for RBAC drift and missing changes
+
+The ClusterRole in the Helm chart must be updated manually: `chart/templates/rbac.yaml`.
+- `make helm-sync` will fail and prints the missing rules. Re-run to confirm.

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,15 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	"$(CONTROLLER_GEN)" rbac:roleName=garage-controller-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+
+# The chart is released separately from the app. App updates should not touch chart/**
+# Making modifications without bumping chart version will trigger a check and block the PR.
+# Run this in the chart release PR only.
+.PHONY: helm-sync
+helm-sync: manifests ## Sync the chart with config/ and report any RBAC left to patch by hand.
 	cp config/crd/bases/*.yaml chart/crds/
+	helm lint chart/ --strict -f "chart/values.test.yaml"
+	go test -tags chart ./test/chart/
 
 .PHONY: generate
 generate: controller-gen license-headers ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -136,12 +144,6 @@ docker-buildx: ## Build multiarch docker image for the manager (set PUSH=true to
 	- $(CONTAINER_TOOL) buildx build $(if $(PUSH),--push) --platform=$(PLATFORMS) --tag ${IMG} $(LABEL_ARGS) .
 	- $(CONTAINER_TOOL) buildx rm garage-storage-controller-builder
 
-.PHONY: build-installer
-build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
-	mkdir -p dist
-	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG}
-	"$(KUSTOMIZE)" build config/overlays/e2e > dist/install.yaml
-
 .PHONY: tag
 tag:
 	@if [ -z "$(TAG)" ]; then \
@@ -170,7 +172,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG}
+	# The image is pinned in the overlay:
 	"$(KUSTOMIZE)" build config/overlays/e2e | "$(KUBECTL)" apply -f -
 
 .PHONY: undeploy

--- a/test/chart/crd_sync_test.go
+++ b/test/chart/crd_sync_test.go
@@ -1,0 +1,74 @@
+// Copyright 2025.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build chart
+
+package chart_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestCRDsMatchConfig(t *testing.T) {
+	_, tFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Join(filepath.Dir(tFile), "..", "..")
+
+	sourceDir := filepath.Join(repoRoot, "config", "crd", "bases")
+	chartDir := filepath.Join(repoRoot, "chart", "crds")
+
+	sources := mustReadCRDs(t, sourceDir)
+	charted := mustReadCRDs(t, chartDir)
+
+	for name, want := range sources {
+		got, ok := charted[name]
+		if !ok {
+			t.Errorf("chart/crds/%s is missing. Run 'make helm-sync'.", name)
+			continue
+		}
+		if !bytes.Equal(want, got) {
+			t.Errorf("chart/crds/%s differs from config/crd/bases/%s. Run 'make helm-sync'.", name, name)
+		}
+	}
+
+	for name := range charted {
+		if _, ok := sources[name]; !ok {
+			t.Errorf("chart/crds/%s has no counterpart in config/crd/bases. Delete it or run 'make helm-sync'.", name)
+		}
+	}
+}
+
+func mustReadCRDs(t *testing.T, dir string) map[string][]byte {
+	t.Helper()
+	entries, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
+	if err != nil {
+		t.Fatalf("globbing %s: %v", dir, err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("no CRDs found in %s", dir)
+	}
+
+	crds := make(map[string][]byte, len(entries))
+	for _, path := range entries {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		crds[filepath.Base(path)] = data
+	}
+	return crds
+}


### PR DESCRIPTION
Adds a new make target `helm-sync`. Running `make manifests` incorrectly copied the updated CRDs into the chart dir. 

Contributing docs with details on the release flow added as well.