### PR TITLE
feat(controller): Emit Warning events when namespace RBAC denies access

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -224,6 +224,7 @@ func main() {
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		garageClient.AccessKeyClient,
+		mgr.GetEventRecorderFor("garage-accesskey-controller"),
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AccessKey")
 		os.Exit(1)

--- a/internal/controller/accesskey_controller.go
+++ b/internal/controller/accesskey_controller.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -47,13 +48,20 @@ type AccessKeyReconciler struct {
 	client    client.Client
 	scheme    *runtime.Scheme
 	accessKey AccessKeyManager
+	recorder  record.EventRecorder
 }
 
-func NewAccessKeyReconciler(c client.Client, s *runtime.Scheme, keyMgr AccessKeyManager) *AccessKeyReconciler {
+func NewAccessKeyReconciler(
+	c client.Client,
+	s *runtime.Scheme,
+	keyMgr AccessKeyManager,
+	recorder record.EventRecorder,
+) *AccessKeyReconciler {
 	return &AccessKeyReconciler{
 		client:    c,
 		scheme:    s,
 		accessKey: keyMgr,
+		recorder:  recorder,
 	}
 }
 
@@ -75,6 +83,7 @@ type AccessKeyManager interface {
 // +kubebuilder:rbac:groups=garage.getclustered.net,resources=accesskeys,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=garage.getclustered.net,resources=accesskeys/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=garage.getclustered.net,resources=accesskeys/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *AccessKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var accessKey garagev1alpha1.AccessKey
@@ -171,6 +180,11 @@ func (r *AccessKeyReconciler) reconcileAccessKey(ctx context.Context, key *Acces
 		if errors.Is(err, errNameConflict) {
 			key.markNotReady(KeySecretReady, ReasonSecretNameConflict, "Conflict: %s", err.Error())
 			return nil
+		}
+		if apierrors.IsForbidden(err) {
+			r.recorder.Eventf(key.Object, corev1.EventTypeWarning, ReasonSecretAccessForbidden,
+				"Cannot access Secrets in namespace %q: %v. %s",
+				key.Object.Namespace, err, rbacRemedyMsg)
 		}
 		key.markNotReady(KeySecretReady, "SecretSetupFailed", "Failed to set up secret for credentials: %v", err)
 		return err

--- a/internal/controller/accesskey_controller_test.go
+++ b/internal/controller/accesskey_controller_test.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -27,6 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,6 +143,37 @@ var _ = Describe("AccessKey Controller", func() {
 
 			}).Should(Succeed())
 		})
+
+		It("should emit SecretAccessForbidden event when RBAC denies Secret access", func() {
+			By("reconciling in a namespace where the controller has no access")
+			rec := record.NewFakeRecorder(10)
+			denied := forbidClientFake{Client: k8sClient, resource: forbidSecrets}
+			sut := NewAccessKeyReconciler(denied, k8sClient.Scheme(), newAccessMgrFake(), rec)
+
+			_, err := sut.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).To(HaveOccurred())
+
+			By("receiving SecretAccessForbidden event")
+			Eventually(rec.Events).Should(Receive(ContainSubstring("Warning SecretAccessForbidden")))
+		})
+
+		It("should not emit SecretAccessForbidden when no RBAC error", func() {
+			By("reconciling with unrelated Secret read fail")
+			rec := record.NewFakeRecorder(10)
+			failing := failGetClientFake{Client: k8sClient, resource: forbidSecrets, err: errors.New("foo failed bar")}
+			sut := NewAccessKeyReconciler(failing, k8sClient.Scheme(), newAccessMgrFake(), rec)
+
+			_, err := sut.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).To(HaveOccurred())
+
+			By("emitting no RBAC warning")
+			Consistently(rec.Events).ShouldNot(Receive(ContainSubstring(ReasonSecretAccessForbidden)))
+		})
+
 		It("creates kubernetes secret with data from external access key", func() {
 			sut, extAPI := setup()
 			_, _ = sut.Reconcile(ctx, reconcile.Request{
@@ -527,7 +560,7 @@ func namespacedName(m metav1.ObjectMeta) types.NamespacedName {
 func setup() (*AccessKeyReconciler, *accessMgrFake) {
 	externalAPI := newAccessMgrFake()
 
-	return NewAccessKeyReconciler(k8sClient, k8sClient.Scheme(), externalAPI), externalAPI
+	return NewAccessKeyReconciler(k8sClient, k8sClient.Scheme(), externalAPI, record.NewFakeRecorder(10)), externalAPI
 }
 
 type accessMgrFake struct {

--- a/internal/controller/accesspolicy_manager_test.go
+++ b/internal/controller/accesspolicy_manager_test.go
@@ -63,7 +63,7 @@ var _ = Describe("AccessPolicy controller manager", Ordered, func() {
 		// sync with manager setup in main:
 		Expect(NewBucketReconciler(mgr.GetClient(), mgr.GetScheme(), newS3APIFake(), "http://s3.test.foo", nil, mgr.GetEventRecorderFor("garage-bucket-controller")).
 			SetupWithManager(mgr)).To(Succeed())
-		Expect(NewAccessKeyReconciler(mgr.GetClient(), mgr.GetScheme(), newAccessMgrFake()).
+		Expect(NewAccessKeyReconciler(mgr.GetClient(), mgr.GetScheme(), newAccessMgrFake(), mgr.GetEventRecorderFor("garage-accesskey-controller")).
 			SetupWithManager(mgr)).To(Succeed())
 		Expect(NewAccessPolicyReconciler(mgr.GetClient(), mgr.GetScheme(), apiClient).
 			SetupWithManager(mgr)).To(Succeed())

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -194,6 +194,11 @@ func (r *BucketReconciler) reconcileBucket(ctx context.Context, bucket *garagev1
 			)
 			return ctrl.Result{}, nil
 		}
+		if apierrors.IsForbidden(err) {
+			r.recorder.Eventf(bucket, corev1.EventTypeWarning, ReasonConfigMapAccessForbidden,
+				"Cannot access ConfigMaps in namespace %q: %v. %s",
+				bucket.Namespace, err, rbacRemedyMsg)
+		}
 		updateBucketCMCondition(bucket, metav1.ConditionFalse,
 			"ConfigMapCreateError",
 			"Unable to create ConfigMap: %v",
@@ -321,6 +326,14 @@ func (r *BucketReconciler) resolveExistingBucket(ctx context.Context, bucket *ga
 	var secret corev1.Secret
 	err := r.client.Get(ctx, client.ObjectKey{Namespace: bucket.Namespace, Name: spec.OwnerKeySecret}, &secret)
 	if err != nil {
+		if apierrors.IsForbidden(err) {
+			r.recorder.Eventf(bucket, corev1.EventTypeWarning, ReasonSecretAccessForbidden,
+				"Cannot access Secrets in namespace %q: %v. %s",
+				bucket.Namespace, err, rbacRemedyMsg)
+			markBucketNotReady(bucket, ReasonSecretAccessForbidden,
+				"Cannot access Secret %q: %v", spec.OwnerKeySecret, err)
+			return s3.Bucket{}, "", fmt.Errorf("get owner key secret: %w", err)
+		}
 		markBucketNotReady(bucket, ReasonOwnerKeySecretNotFound, "Secret %q not found: %v", spec.OwnerKeySecret, err)
 		return s3.Bucket{}, "", fmt.Errorf("get owner key secret: %w", err)
 	}

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -301,6 +301,45 @@ var _ = Describe("Bucket Controller", func() {
 			Eventually(rec.Events).Should(Receive(ContainSubstring("Warning BucketCreateFailed")))
 		})
 
+		It("should emit ConfigMapAccessForbidden event when RBAC denies ConfigMap access", func() {
+			By("creating a Bucket resource")
+			bucket := newBucket(namespace)
+			Expect(k8sClient.Create(ctx, &bucket)).To(Succeed())
+
+			By("reconciling in a namespace with no access to ConfigMaps")
+			rec := record.NewFakeRecorder(10)
+			s3Fake := newS3APIFake()
+			denied := forbidClientFake{Client: k8sClient, resource: forbidConfigMaps}
+			sut := NewBucketReconciler(denied, k8sClient.Scheme(), s3Fake, "https://s3.test:9000", nil, rec)
+			_, err := sut.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName(bucket.ObjectMeta)})
+			Expect(err).To(HaveOccurred())
+
+			By("receiving ConfigMapAccessForbidden event")
+			Eventually(rec.Events).Should(Receive(ContainSubstring("Warning ConfigMapAccessForbidden")), "event should match spec")
+		})
+
+		It("should not emit ConfigMapAccessForbidden for different reason", func() {
+			By("creating a Bucket resource")
+			bucket := newBucket(namespace)
+			Expect(k8sClient.Create(ctx, &bucket)).To(Succeed())
+
+			By("reconciling against a client with failing ConfigMap read")
+			rec := record.NewFakeRecorder(10)
+			s3Fake := newS3APIFake()
+			By("failing for unrelated reason")
+			failing := failGetClientFake{
+				Client:   k8sClient,
+				resource: forbidConfigMaps,
+				err:      errors.New("etcd unavailable"),
+			}
+			sut := NewBucketReconciler(failing, k8sClient.Scheme(), s3Fake, "https://s3.test:9000", nil, rec)
+			_, err := sut.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName(bucket.ObjectMeta)})
+			Expect(err).To(HaveOccurred())
+
+			By("emitting no RBAC warning")
+			Consistently(rec.Events).ShouldNot(Receive(ContainSubstring(ReasonConfigMapAccessForbidden)))
+		})
+
 		It("recovers from conflict once configMapName is set", func() {
 			conflictingName := "foobar"
 			originalData := map[string]string{"foo": "bar"}
@@ -723,11 +762,13 @@ var _ = Describe("Bucket Controller", func() {
 			existingBucketID := fixture.RandAlpha(12)
 
 			By("pre-creating the Garage bucket")
-			sut, s3API, _ := setupBucket()
+			rec := record.NewFakeRecorder(10)
+			s3API := newS3APIFake()
 			s3API.buckets[existingBucketID] = s3.Bucket{
 				ID:            existingBucketID,
 				GlobalAliases: []string{existingBucketName},
 			}
+			sut := NewBucketReconciler(k8sClient, k8sClient.Scheme(), s3API, "https://s3.foo/bar:123", newPermissionClientFake(), rec)
 
 			By("creating a Bucket resource referencing a non-existent Secret")
 			bucket := newExistingBucketResource(namespace, "unknown-secret-"+fixture.RandAlpha(4))
@@ -744,6 +785,43 @@ var _ = Describe("Bucket Controller", func() {
 			By("top-level Ready condition is False")
 			Expect(checkCondition(bucket.Status.Conditions, Ready, metav1.ConditionFalse)).To(Succeed())
 			Expect(meta.FindStatusCondition(bucket.Status.Conditions, Ready).Reason).To(Equal(ReasonOwnerKeySecretNotFound))
+
+			By("emitting no RBAC warning")
+			Consistently(rec.Events).ShouldNot(Receive(ContainSubstring(ReasonSecretAccessForbidden)))
+		})
+
+		It("emits SecretAccessForbidden event when RBAC denies access to the owner key Secret", func() {
+			existingBucketID := fixture.RandAlpha(12)
+
+			By("pre-creating the Garage bucket")
+			s3API := newS3APIFake()
+			s3API.buckets[existingBucketID] = s3.Bucket{
+				ID:            existingBucketID,
+				GlobalAliases: []string{existingBucketName},
+			}
+
+			By("creating a Secret with the key")
+			secret := keySecret(namespace, ownerKeyID)
+			Expect(k8sClient.Create(ctx, &secret)).To(Succeed())
+
+			By("creating the Bucket CR")
+			bucket := newExistingBucketResource(namespace, secret.Name)
+			Expect(k8sClient.Create(ctx, &bucket)).To(Succeed())
+
+			By("reconciling in a namespace with no access to Secrets")
+			rec := record.NewFakeRecorder(10)
+			denied := forbidClientFake{Client: k8sClient, resource: forbidSecrets}
+			sut := NewBucketReconciler(
+				denied, k8sClient.Scheme(), s3API, "https://s3.foo/bar:123", newPermissionClientFake(), rec)
+			shouldReconcile(sut, bucket.ObjectMeta)
+
+			By("receiving SecretAccessForbidden event")
+			Eventually(rec.Events).Should(Receive(ContainSubstring("Warning SecretAccessForbidden")))
+
+			By("BucketReady condition is False with the RBAC reason")
+			Expect(k8sClient.Get(ctx, namespacedName(bucket.ObjectMeta), &bucket)).To(Succeed())
+			Expect(checkCondition(bucket.Status.Conditions, BucketReady, metav1.ConditionFalse)).To(Succeed())
+			Expect(meta.FindStatusCondition(bucket.Status.Conditions, BucketReady).Reason).To(Equal(ReasonSecretAccessForbidden))
 		})
 	})
 })

--- a/internal/controller/controller_fakes_test.go
+++ b/internal/controller/controller_fakes_test.go
@@ -16,8 +16,13 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/bmarinov/garage-storage-controller/internal/s3"
 )
@@ -48,3 +53,59 @@ func (p *permissionClientFake) GetPermissions(_ context.Context, keyID, bucketID
 
 var _ PermissionClient = &permissionClientFake{}
 var _ OwnershipVerifier = &permissionClientFake{}
+
+var errRBACDenied = errors.New("RBAC: access denied in fake")
+
+type forbiddenResource string
+
+const (
+	forbidConfigMaps forbiddenResource = "configmaps"
+	forbidSecrets    forbiddenResource = "secrets"
+)
+
+func (r forbiddenResource) matches(obj client.Object) bool {
+	switch obj.(type) {
+	case *corev1.ConfigMap:
+		return r == forbidConfigMaps
+	case *corev1.Secret:
+		return r == forbidSecrets
+	default:
+		return false
+	}
+}
+
+// forbidClientFake denies Get on one configured resource.
+type forbidClientFake struct {
+	client.Client
+	resource forbiddenResource
+}
+
+func (c forbidClientFake) Get(
+	ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption,
+) error {
+	if c.resource.matches(obj) {
+		return apierrors.NewForbidden(corev1.Resource(string(c.resource)), key.Name, errRBACDenied)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+// failGetClientFake fails Get on one resource type with a custom error.
+type failGetClientFake struct {
+	client.Client
+	resource forbiddenResource
+	err      error
+}
+
+func (c failGetClientFake) Get(
+	ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption,
+) error {
+	if c.resource.matches(obj) {
+		return c.err
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+var (
+	_ client.Client = forbidClientFake{}
+	_ client.Client = failGetClientFake{}
+)

--- a/internal/controller/reasons.go
+++ b/internal/controller/reasons.go
@@ -17,3 +17,12 @@ package controller
 const ReasonBucketCreated = "BucketCreated" // type Normal: new bucket in Garage
 
 const ReasonBucketCreateFailed = "BucketCreateFailed" // type Warning: bucket creation in Garage failed
+
+// RBAC denials in the target namespace.
+const (
+	ReasonConfigMapAccessForbidden = "ConfigMapAccessForbidden" // type Warning: no ConfigMap access in the namespace
+	ReasonSecretAccessForbidden    = "SecretAccessForbidden"    // type Warning: no Secret access in the namespace
+)
+
+// rbacRemedyMsg provides additional context for the RBAC failure.
+const rbacRemedyMsg = "Grant the controller namespace-access Role and RoleBinding."


### PR DESCRIPTION
This PR adds Warning events specific to RBAC issues in tenant namespaces. The two new events are emitted in the Bucket and AccessKey reconcile phase respectively:
- `ConfigMapAccessForbidden`
- `SecretAccessForbidden`

