### PR TITLE
fix(accesskey): Persist status conditions when reconcile fails

### DIFF
--- a/internal/controller/accesskey_conditions.go
+++ b/internal/controller/accesskey_conditions.go
@@ -31,6 +31,7 @@ const (
 	AccessKeyReady           string = "AccessKeyReady"
 	KeySecretReady           string = "KeySecretReady"
 	ReasonSecretNameConflict string = "SecretNameConflict"
+	ReasonSecretSetupFailed  string = "SecretSetupFailed"
 )
 
 func (k *AccessKey) InitializeConditions() {

--- a/internal/controller/accesskey_controller.go
+++ b/internal/controller/accesskey_controller.go
@@ -131,27 +131,33 @@ func (r *AccessKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	key.InitializeConditions()
 
 	err = r.reconcileAccessKey(ctx, &key)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	updateAccessKeyCondition(&accessKey)
 
 	if !equality.Semantic.DeepEqual(*orig, accessKey.Status) {
-		var a garagev1alpha1.AccessKey
-		err = r.client.Get(ctx, req.NamespacedName, &a)
-		if err != nil {
-			return ctrl.Result{}, err
+		statusErr := r.updateStatus(ctx, req.NamespacedName, accessKey.Status)
+		if statusErr != nil {
+			if apierrors.IsConflict(statusErr) {
+				return ctrl.Result{}, nil
+			}
+			if err == nil {
+				return ctrl.Result{}, statusErr
+			}
 		}
-		a.Status = accessKey.Status
-		err = r.client.Status().Update(ctx, &a)
-		if apierrors.IsConflict(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, err
+}
+
+func (r *AccessKeyReconciler) updateStatus(
+	ctx context.Context, name types.NamespacedName, status garagev1alpha1.AccessKeyStatus,
+) error {
+	var latest garagev1alpha1.AccessKey
+	if err := r.client.Get(ctx, name, &latest); err != nil {
+		return fmt.Errorf("re-reading access key for status update: %w", err)
+	}
+	latest.Status = status
+
+	return r.client.Status().Update(ctx, &latest)
 }
 
 func (r *AccessKeyReconciler) reconcileAccessKey(ctx context.Context, key *AccessKey) error {
@@ -186,7 +192,7 @@ func (r *AccessKeyReconciler) reconcileAccessKey(ctx context.Context, key *Acces
 				"Cannot access Secrets in namespace %q: %v. %s",
 				key.Object.Namespace, err, rbacRemedyMsg)
 		}
-		key.markNotReady(KeySecretReady, "SecretSetupFailed", "Failed to set up secret for credentials: %v", err)
+		key.markNotReady(KeySecretReady, ReasonSecretSetupFailed, "Failed to set up secret for credentials: %v", err)
 		return err
 	}
 

--- a/internal/controller/accesskey_controller_test.go
+++ b/internal/controller/accesskey_controller_test.go
@@ -144,6 +144,29 @@ var _ = Describe("AccessKey Controller", func() {
 			}).Should(Succeed())
 		})
 
+		It("persists the failure reason in status when the Secret cannot be read", func() {
+			By("reconciling against a client with denied Secret read")
+			failing := failGetClientFake{Client: k8sClient, resource: forbidSecrets, err: errors.New("etcd unavailable")}
+			sut := NewAccessKeyReconciler(failing, k8sClient.Scheme(), newAccessMgrFake(), record.NewFakeRecorder(10))
+
+			_, err := sut.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).To(HaveOccurred())
+
+			By("conditions updated in the failed reconcile")
+			var accessKey garagev1alpha1.AccessKey
+			Expect(k8sClient.Get(ctx, typeNamespacedName, &accessKey)).To(Succeed())
+			Expect(checkCondition(accessKey.Status.Conditions, KeySecretReady, metav1.ConditionFalse)).To(Succeed())
+			Expect(meta.FindStatusCondition(accessKey.Status.Conditions, KeySecretReady).Reason).
+				To(Equal(ReasonSecretSetupFailed))
+
+			By("cause is in the top-level condition")
+			Expect(checkCondition(accessKey.Status.Conditions, Ready, metav1.ConditionFalse)).To(Succeed())
+			Expect(meta.FindStatusCondition(accessKey.Status.Conditions, Ready).Reason).
+				To(Equal(ReasonSecretSetupFailed))
+		})
+
 		It("should emit SecretAccessForbidden event when RBAC denies Secret access", func() {
 			By("reconciling in a namespace where the controller has no access")
 			rec := record.NewFakeRecorder(10)


### PR DESCRIPTION
Reconcile returned early on error before Status was written. A failing AccessKey showed blank Ready & Reason. Conditions are now patched regardless of the reconcile result. Matches the Bucket controller behavior.