### PR TITLE
feat(controller): report specific rbac reason in error conditions

### DIFF
--- a/internal/controller/accesskey_conditions.go
+++ b/internal/controller/accesskey_conditions.go
@@ -64,12 +64,9 @@ func markAccessKeyNotReady(k *garagev1alpha1.AccessKey,
 		args...)
 }
 
-func (k *AccessKey) markNotReady(condType string,
-	reason,
-	message string,
-	args ...any) {
+func (k *AccessKey) markSecretNotReady(reason, message string, args ...any) {
 	cond := metav1.Condition{
-		Type:               condType,
+		Type:               KeySecretReady,
 		Status:             metav1.ConditionFalse,
 		Reason:             reason,
 		Message:            fmt.Sprintf(message, args...),

--- a/internal/controller/accesskey_controller.go
+++ b/internal/controller/accesskey_controller.go
@@ -184,15 +184,18 @@ func (r *AccessKeyReconciler) reconcileAccessKey(ctx context.Context, key *Acces
 	err = r.ensureSecret(ctx, *key.Object, externalKey.Secret)
 	if err != nil {
 		if errors.Is(err, errNameConflict) {
-			key.markNotReady(KeySecretReady, ReasonSecretNameConflict, "Conflict: %s", err.Error())
+			key.markSecretNotReady(ReasonSecretNameConflict, "Conflict: %s", err.Error())
 			return nil
 		}
 		if apierrors.IsForbidden(err) {
 			r.recorder.Eventf(key.Object, corev1.EventTypeWarning, ReasonSecretAccessForbidden,
 				"Cannot access Secrets in namespace %q: %v. %s",
 				key.Object.Namespace, err, rbacRemedyMsg)
+			key.markSecretNotReady(ReasonSecretAccessForbidden,
+				"Cannot access Secrets in namespace %q: %v", key.Object.Namespace, err)
+			return err
 		}
-		key.markNotReady(KeySecretReady, ReasonSecretSetupFailed, "Failed to set up secret for credentials: %v", err)
+		key.markSecretNotReady(ReasonSecretSetupFailed, "Failed to set up secret for credentials: %v", err)
 		return err
 	}
 
@@ -200,7 +203,7 @@ func (r *AccessKeyReconciler) reconcileAccessKey(ctx context.Context, key *Acces
 		err = r.cleanupOldSecret(ctx, key.Object.Status.SecretName, key.Object.Namespace)
 		if err != nil {
 			logf.FromContext(ctx).Error(err, "cleaning up old secret on spec change", "accessKeyUID", key.Object.UID)
-			key.markNotReady(KeySecretReady, "SecretCleanupFailed",
+			key.markSecretNotReady("SecretCleanupFailed",
 				"New secret created but failed to delete old secret %q: %v",
 				key.Object.Status.SecretName, err)
 

--- a/internal/controller/accesskey_controller_test.go
+++ b/internal/controller/accesskey_controller_test.go
@@ -180,6 +180,15 @@ var _ = Describe("AccessKey Controller", func() {
 
 			By("receiving SecretAccessForbidden event")
 			Eventually(rec.Events).Should(Receive(ContainSubstring("Warning SecretAccessForbidden")))
+
+			By("naming RBAC as the cause in the conditions, not a generic setup failure")
+			var accessKey garagev1alpha1.AccessKey
+			Expect(k8sClient.Get(ctx, typeNamespacedName, &accessKey)).To(Succeed())
+			Expect(checkCondition(accessKey.Status.Conditions, KeySecretReady, metav1.ConditionFalse)).To(Succeed())
+			Expect(meta.FindStatusCondition(accessKey.Status.Conditions, KeySecretReady).Reason).
+				To(Equal(ReasonSecretAccessForbidden))
+			Expect(meta.FindStatusCondition(accessKey.Status.Conditions, Ready).Reason).
+				To(Equal(ReasonSecretAccessForbidden))
 		})
 
 		It("should not emit SecretAccessForbidden when no RBAC error", func() {

--- a/internal/controller/accesspolicy_controller.go
+++ b/internal/controller/accesspolicy_controller.go
@@ -165,12 +165,14 @@ func (r *AccessPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	if !equality.Semantic.DeepEqual(*oldStatus, policy.Status) {
-		err = r.client.Status().Patch(ctx, &policy, client.Merge, client.FieldOwner(bucketControllerName))
-		if err != nil {
-			if apierrors.IsConflict(err) {
+		patchErr := r.client.Status().Patch(ctx, &policy, client.Merge, client.FieldOwner(bucketControllerName))
+		if patchErr != nil {
+			if apierrors.IsConflict(patchErr) {
 				return ctrl.Result{}, nil
 			}
-			return ctrl.Result{}, err
+			if resultErr == nil {
+				return ctrl.Result{}, patchErr
+			}
 		}
 	}
 

--- a/internal/controller/bucket_conditions.go
+++ b/internal/controller/bucket_conditions.go
@@ -26,6 +26,7 @@ const (
 	BucketReady                       string = "BucketReady"
 	BucketConfigMapReady              string = "BucketConfigMapReady"
 	ReasonConfigMapNameConflict       string = "ConfigMapNameConflict"
+	ReasonConfigMapCreateError        string = "ConfigMapCreateError"
 	ReasonOwnerKeySecretNotFound      string = "OwnerKeySecretNotFound"
 	ReasonOwnershipVerificationFailed string = "OwnershipVerificationFailed"
 )

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -198,9 +198,15 @@ func (r *BucketReconciler) reconcileBucket(ctx context.Context, bucket *garagev1
 			r.recorder.Eventf(bucket, corev1.EventTypeWarning, ReasonConfigMapAccessForbidden,
 				"Cannot access ConfigMaps in namespace %q: %v. %s",
 				bucket.Namespace, err, rbacRemedyMsg)
+			updateBucketCMCondition(bucket, metav1.ConditionFalse,
+				ReasonConfigMapAccessForbidden,
+				"Cannot access ConfigMaps in namespace %q: %v",
+				bucket.Namespace, err,
+			)
+			return ctrl.Result{}, err
 		}
 		updateBucketCMCondition(bucket, metav1.ConditionFalse,
-			"ConfigMapCreateError",
+			ReasonConfigMapCreateError,
 			"Unable to create ConfigMap: %v",
 			err,
 		)

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -316,6 +316,14 @@ var _ = Describe("Bucket Controller", func() {
 
 			By("receiving ConfigMapAccessForbidden event")
 			Eventually(rec.Events).Should(Receive(ContainSubstring("Warning ConfigMapAccessForbidden")), "event should match spec")
+
+			By("naming RBAC as the cause in the conditions, not a generic create error")
+			Expect(k8sClient.Get(ctx, namespacedName(bucket.ObjectMeta), &bucket)).To(Succeed())
+			Expect(checkCondition(bucket.Status.Conditions, BucketConfigMapReady, metav1.ConditionFalse)).To(Succeed())
+			Expect(meta.FindStatusCondition(bucket.Status.Conditions, BucketConfigMapReady).Reason).
+				To(Equal(ReasonConfigMapAccessForbidden))
+			Expect(meta.FindStatusCondition(bucket.Status.Conditions, Ready).Reason).
+				To(Equal(ReasonConfigMapAccessForbidden))
 		})
 
 		It("should not emit ConfigMapAccessForbidden for different reason", func() {
@@ -338,6 +346,11 @@ var _ = Describe("Bucket Controller", func() {
 
 			By("emitting no RBAC warning")
 			Consistently(rec.Events).ShouldNot(Receive(ContainSubstring(ReasonConfigMapAccessForbidden)))
+
+			By("keeping the generic reason in the conditions")
+			Expect(k8sClient.Get(ctx, namespacedName(bucket.ObjectMeta), &bucket)).To(Succeed())
+			Expect(meta.FindStatusCondition(bucket.Status.Conditions, BucketConfigMapReady).Reason).
+				To(Equal(ReasonConfigMapCreateError))
 		})
 
 		It("recovers from conflict once configMapName is set", func() {


### PR DESCRIPTION
The ConfigMap and owner key Secret reconcile paths reported generic errors when RBAC was denied for a namespace.
This change sets `ConfigMapAccessForbidden` and `SecretAccessForbidden` as the reason and adds a more specific message.

Minor adjustment to the AccessPolicy controller so the logs show the correct Reconcile error.
